### PR TITLE
fix(api): implement heartbeat-based online status tracking

### DIFF
--- a/hbbs-patch-v2/src/rendezvous_server.rs
+++ b/hbbs-patch-v2/src/rendezvous_server.rs
@@ -442,7 +442,9 @@ impl RendezvousServer {
                         }
                     }
                     if changed {
-                        self.pm.update_pk(id, peer, addr, rk.uuid, rk.pk, ip).await;
+                        self.pm.update_pk(id.clone(), peer, addr, rk.uuid, rk.pk, ip).await;
+                    } else {
+                        self.pm.touch_peer(&id).await;
                     }
                     let mut msg_out = RendezvousMessage::new();
                     msg_out.set_register_pk_response(RegisterPkResponse {

--- a/web-nodejs/routes/rustdesk-api.routes.js
+++ b/web-nodejs/routes/rustdesk-api.routes.js
@@ -73,10 +73,18 @@ router.get('/api/login-options', (req, res) => {
  * Must return a valid JSON response to prevent client errors.
  */
 router.post('/api/heartbeat', (req, res) => {
+    const { id } = req.body || {};
+    if (id) {
+        db.setDeviceOnline(id);
+    }
+    
     const token = extractBearerToken(req);
     if (token) {
         const user = authService.validateAccessToken(token);
         if (user) {
+            if (user.clientId && !id) {
+                db.setDeviceOnline(user.clientId);
+            }
             return res.json({ modified_at: new Date().toISOString() });
         }
     }
@@ -89,6 +97,10 @@ router.post('/api/heartbeat', (req, res) => {
  * Acknowledge the report.
  */
 router.post('/api/sysinfo', (req, res) => {
+    const { id } = req.body || {};
+    if (id) {
+        db.setDeviceOnline(id);
+    }
     return res.json({});
 });
 

--- a/web-nodejs/services/database.js
+++ b/web-nodejs/services/database.js
@@ -386,6 +386,20 @@ function countDevices(filters = {}) {
     return db.prepare(sql).get(...params).count;
 }
 
+/**
+ * Set device online status (used by Client API heartbeats)
+ */
+function setDeviceOnline(id) {
+    if (!id) return;
+    try {
+        getDb().prepare(
+            "UPDATE peer SET status_online = 1, last_online = datetime('now') WHERE id = ? AND is_deleted = 0"
+        ).run(id);
+    } catch (err) {
+        console.error('Failed to set device online:', err.message);
+    }
+}
+
 // ==================== User Operations ====================
 
 /**
@@ -851,6 +865,7 @@ module.exports = {
     setBanStatus,
     getStats,
     countDevices,
+    setDeviceOnline,
     // Users
     getUserByUsername,
     getUserById,

--- a/web-nodejs/services/hbbsApi.js
+++ b/web-nodejs/services/hbbsApi.js
@@ -120,10 +120,10 @@ async function syncOnlineStatus(db) {
         // Reset all to offline
         db.prepare('UPDATE peer SET status_online = 0').run();
         
-        // Set online for those from API
+        // Set online for those from API (Removed last_online = datetime('now') to prevent infinite loop)
         if (onlineIds.size > 0) {
             const placeholders = Array(onlineIds.size).fill('?').join(',');
-            db.prepare(`UPDATE peer SET status_online = 1, last_online = datetime('now') WHERE id IN (${placeholders})`)
+            db.prepare(`UPDATE peer SET status_online = 1 WHERE id IN (${placeholders})`)
                 .run(...onlineIds);
         }
         


### PR DESCRIPTION
## Description
This PR addresses the issue where devices appear as "Offline" in the Web UI despite being accessible. It implements a dual fix:
1. **Node.js:** Updates the database `last_online` timestamp whenever a device sends an HTTP heartbeat or sysinfo packet to port 21121.
2. **Rust:** Fixes the rendezvous logic to ensure `touch_peer` is called even when the public key hasn't changed.

## Type of Change
- [x] Bug fix

## Checklist
- [x] Code follows style guidelines
- [x] Tested with real RustDesk clients