### PR TITLE
Go server: stability wave 1 (compat-safe)

### DIFF
--- a/.github/workflows/go-server-ci.yml
+++ b/.github/workflows/go-server-ci.yml
@@ -1,0 +1,34 @@
+# BetterDesk Go server — vet + tests on push/PR
+name: Go Server CI
+
+on:
+  push:
+    branches: [main, dev]
+    paths:
+      - 'betterdesk-server/**'
+      - '.github/workflows/go-server-ci.yml'
+  pull_request:
+    paths:
+      - 'betterdesk-server/**'
+      - '.github/workflows/go-server-ci.yml'
+
+defaults:
+  run:
+    working-directory: betterdesk-server
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: betterdesk-server/go.mod
+          cache-dependency-path: betterdesk-server/go.sum
+
+      - name: go vet
+        run: go vet ./...
+
+      - name: go test
+        run: go test -race -count=1 ./...

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@
 ## [3.3.15] — 2026-06-14
 
 ### Changed
-- _(none yet)_
+
+- **Go server (stability):** CDAP disconnect cleans all session types (terminal, video, file, audio, desktop); batch peer status DB updates on mass offline; known-peer heartbeats skip registration rate limiter; relay WebSocket uses same per-IP ConnLimiter as TCP; Postgres query timeouts on status updates; org login rate limiting.
+- **CI:** `go-server-ci.yml` runs `go vet` and `go test -race` on changes under `betterdesk-server/`.
 
 ---
 

--- a/betterdesk-server/api/org_handlers.go
+++ b/betterdesk-server/api/org_handlers.go
@@ -758,6 +758,12 @@ func (s *Server) handleSetOrgAddressBook(w http.ResponseWriter, r *http.Request)
 
 // POST /api/org/login
 func (s *Server) handleOrgLogin(w http.ResponseWriter, r *http.Request) {
+	clientIP := s.remoteIP(r)
+	if s.loginLimiter != nil && !s.loginLimiter.Allow(clientIP) {
+		http.Error(w, `{"error":"too many login attempts"}`, http.StatusTooManyRequests)
+		return
+	}
+
 	var body struct {
 		OrgSlug  string `json:"org_slug"`
 		OrgID    string `json:"org_id"`

--- a/betterdesk-server/cdap/desktop.go
+++ b/betterdesk-server/cdap/desktop.go
@@ -367,13 +367,50 @@ func (g *Gateway) HandleDesktopInputError(ctx context.Context, _ *DeviceConn, ms
 }
 
 func (g *Gateway) cleanupDeviceSessions(deviceID, reason string) {
+	ctx := context.Background()
+
 	g.desktopSessions.Range(func(key, value any) bool {
 		ds, ok := value.(*DesktopSession)
 		if !ok || ds.DeviceID != deviceID {
 			return true
 		}
-		g.EndDesktopSession(context.Background(), ds.ID, reason)
-		g.desktopSessions.Delete(key)
+		g.EndDesktopSession(ctx, ds.ID, reason)
+		return true
+	})
+
+	g.terminalSessions.Range(func(key, value any) bool {
+		ts, ok := value.(*TerminalSession)
+		if !ok || ts.DeviceID != deviceID {
+			return true
+		}
+		g.EndTerminalSession(ctx, ts.ID, reason)
+		return true
+	})
+
+	g.videoSessions.Range(func(key, value any) bool {
+		vs, ok := value.(*VideoSession)
+		if !ok || vs.DeviceID != deviceID {
+			return true
+		}
+		g.EndVideoSession(ctx, vs.ID, reason)
+		return true
+	})
+
+	g.fileSessions.Range(func(key, value any) bool {
+		fs, ok := value.(*FileSession)
+		if !ok || fs.DeviceID != deviceID {
+			return true
+		}
+		g.EndFileSession(ctx, fs.ID, reason)
+		return true
+	})
+
+	g.audioSessions.Range(func(key, value any) bool {
+		as, ok := value.(*AudioSession)
+		if !ok || as.DeviceID != deviceID {
+			return true
+		}
+		g.EndAudioSession(ctx, as.ID, reason)
 		return true
 	})
 }

--- a/betterdesk-server/db/database.go
+++ b/betterdesk-server/db/database.go
@@ -422,6 +422,7 @@ type Database interface {
 
 	// Status tracking
 	UpdatePeerStatus(id string, status string, ip string) error
+	BatchUpdatePeerStatus(ids []string, status string) error
 	UpdatePeerSysinfo(id, hostname, os, version string) error
 	SetAllOffline() error
 

--- a/betterdesk-server/db/postgres.go
+++ b/betterdesk-server/db/postgres.go
@@ -18,6 +18,8 @@ type PostgresDB struct {
 	pool *pgxpool.Pool
 	ctx  context.Context
 
+	queryTimeout time.Duration
+
 	// LISTEN/NOTIFY callback (nil = disabled). Set via OnNotify().
 	notifyFunc func(channel, payload string)
 }
@@ -55,7 +57,15 @@ func OpenPostgres(dsn string) (*PostgresDB, error) {
 		return nil, fmt.Errorf("db: PostgreSQL ping: %w", err)
 	}
 
-	return &PostgresDB{pool: pool, ctx: ctx}, nil
+	return &PostgresDB{pool: pool, ctx: ctx, queryTimeout: 30 * time.Second}, nil
+}
+
+// opCtx returns a context for database operations with optional query timeout.
+func (pg *PostgresDB) opCtx() (context.Context, context.CancelFunc) {
+	if pg.queryTimeout <= 0 {
+		return pg.ctx, func() {}
+	}
+	return context.WithTimeout(pg.ctx, pg.queryTimeout)
 }
 
 // Close closes the connection pool.
@@ -753,9 +763,24 @@ func (pg *PostgresDB) GetBannedPeerCount() (int, error) {
 
 // UpdatePeerStatus updates a peer's status and IP, plus last_online timestamp.
 func (pg *PostgresDB) UpdatePeerStatus(id string, status string, ip string) error {
-	_, err := pg.pool.Exec(pg.ctx,
+	ctx, cancel := pg.opCtx()
+	defer cancel()
+	_, err := pg.pool.Exec(ctx,
 		`UPDATE peers SET status = $1, ip = $2, last_online = NOW() WHERE id = $3 AND soft_deleted = FALSE`,
 		status, ip, id)
+	return err
+}
+
+// BatchUpdatePeerStatus sets status for many peers in one query.
+func (pg *PostgresDB) BatchUpdatePeerStatus(ids []string, status string) error {
+	if len(ids) == 0 {
+		return nil
+	}
+	ctx, cancel := pg.opCtx()
+	defer cancel()
+	_, err := pg.pool.Exec(ctx,
+		`UPDATE peers SET status = $1, last_online = NOW() WHERE soft_deleted = FALSE AND id = ANY($2)`,
+		status, ids)
 	return err
 }
 

--- a/betterdesk-server/db/sqlite.go
+++ b/betterdesk-server/db/sqlite.go
@@ -757,6 +757,29 @@ func (s *SQLiteDB) UpdatePeerStatus(id string, status string, ip string) error {
 	return err
 }
 
+// BatchUpdatePeerStatus sets status for many peers in one query (empty ip preserved).
+func (s *SQLiteDB) BatchUpdatePeerStatus(ids []string, status string) error {
+	if len(ids) == 0 {
+		return nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	placeholders := make([]string, len(ids))
+	args := make([]any, 0, len(ids)+1)
+	args = append(args, status)
+	for i, id := range ids {
+		placeholders[i] = "?"
+		args = append(args, id)
+	}
+	query := fmt.Sprintf(
+		`UPDATE peers SET status = ?, last_online = datetime('now') WHERE soft_deleted = 0 AND id IN (%s)`,
+		strings.Join(placeholders, ","),
+	)
+	_, err := s.db.Exec(query, args...)
+	return err
+}
+
 // UpdatePeerSysinfo updates hostname, os, and version for a peer.
 // Only non-empty values overwrite existing data.
 func (s *SQLiteDB) UpdatePeerSysinfo(id, hostname, os, version string) error {

--- a/betterdesk-server/db/sqlite_test.go
+++ b/betterdesk-server/db/sqlite_test.go
@@ -248,6 +248,58 @@ func TestUpdatePeerStatusIgnoresSoftDeleted(t *testing.T) {
 	}
 }
 
+func TestBatchUpdatePeerStatus(t *testing.T) {
+	db := newTestDB(t)
+
+	for _, id := range []string{"BATCH1", "BATCH2"} {
+		if err := db.UpsertPeer(&Peer{ID: id, Status: "ONLINE", IP: "10.0.0.1"}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if err := db.BatchUpdatePeerStatus([]string{"BATCH1", "BATCH2", "MISSING1"}, "DEGRADED"); err != nil {
+		t.Fatal(err)
+	}
+
+	check := func(id, wantStatus string) {
+		t.Helper()
+		p, err := db.GetPeer(id)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if p == nil {
+			t.Fatalf("peer %s not found", id)
+		}
+		if p.Status != wantStatus {
+			t.Fatalf("peer %s status = %q, want %q", id, p.Status, wantStatus)
+		}
+	}
+	check("BATCH1", "DEGRADED")
+	check("BATCH2", "DEGRADED")
+}
+
+func TestBatchUpdatePeerStatusIgnoresSoftDeleted(t *testing.T) {
+	db := newTestDB(t)
+	if err := db.UpsertPeer(&Peer{ID: "BATCHDEL", Status: "ONLINE"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.DeletePeer("BATCHDEL"); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.BatchUpdatePeerStatus([]string{"BATCHDEL"}, "CRITICAL"); err != nil {
+		t.Fatal(err)
+	}
+	peers, err := db.ListPeers(true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, p := range peers {
+		if p.ID == "BATCHDEL" && p.Status == "CRITICAL" {
+			t.Fatal("BatchUpdatePeerStatus must not update soft-deleted peer")
+		}
+	}
+}
+
 func TestBanSystem(t *testing.T) {
 	db := newTestDB(t)
 

--- a/betterdesk-server/relay/ws.go
+++ b/betterdesk-server/relay/ws.go
@@ -63,6 +63,19 @@ func (s *Server) serveWS() {
 // After upgrade, the first binary frame must be a RequestRelay (with UUID).
 // Then we convert the WS to a net.Conn and feed it into the existing pairing logic.
 func (s *Server) handleWSRelayUpgrade(w http.ResponseWriter, r *http.Request) {
+	ip, _, _ := net.SplitHostPort(r.RemoteAddr)
+	if ip == "" {
+		ip = r.RemoteAddr
+	}
+	if s.connLimiter != nil && !s.connLimiter.Acquire(ip) {
+		log.Printf("[relay] WS connection rejected from %s (per-IP limit exceeded)", ip)
+		http.Error(w, "too many connections", http.StatusServiceUnavailable)
+		return
+	}
+	if s.connLimiter != nil {
+		defer s.connLimiter.Release(ip)
+	}
+
 	opts := &websocket.AcceptOptions{}
 
 	// Secure-by-default origin validation:

--- a/betterdesk-server/signal/handler.go
+++ b/betterdesk-server/signal/handler.go
@@ -79,13 +79,15 @@ func (s *Server) publishPeerOnline(id string) {
 }
 
 func (s *Server) allowRegistration(clientHost, peerID string, knownPeer bool) bool {
+	// Registered peers send heartbeats every ~12s — rate-limiting those adds
+	// lock contention without abuse benefit (peer ID is already validated in memory).
+	if knownPeer {
+		return true
+	}
 	if s.limiter == nil {
 		return true
 	}
-	if !knownPeer {
-		return s.limiter.Allow(signalLimiterKey("reg-new", clientHost, ""))
-	}
-	return s.limiter.Allow(signalLimiterKey("reg", clientHost, peerID))
+	return s.limiter.Allow(signalLimiterKey("reg-new", clientHost, ""))
 }
 
 func (s *Server) allowSignalConnection(clientHost string) bool {

--- a/betterdesk-server/signal/handler_test.go
+++ b/betterdesk-server/signal/handler_test.go
@@ -164,24 +164,17 @@ func TestHandleRegisterPeerWSRejectsSoftDeletedHeartbeat(t *testing.T) {
 	}
 }
 
-func TestRegistrationLimiterUsesPeerScopedBucket(t *testing.T) {
+func TestRegistrationLimiterSkipsKnownPeerHeartbeats(t *testing.T) {
 	srv, _ := newTestSignalServer(t, config.EnrollmentModeOpen)
 	limiter := ratelimit.NewIPLimiter(2, time.Minute, time.Minute)
 	t.Cleanup(limiter.Stop)
 	srv.SetRateLimiter(limiter)
 
 	clientHost := "172.29.1.20"
-	if !srv.allowRegistration(clientHost, "PROXYA1", true) {
-		t.Fatal("first registration for PROXYA1 should be allowed")
-	}
-	if !srv.allowRegistration(clientHost, "PROXYA1", true) {
-		t.Fatal("second registration for PROXYA1 should be allowed")
-	}
-	if srv.allowRegistration(clientHost, "PROXYA1", true) {
-		t.Fatal("third registration for the same peer should be rate limited")
-	}
-	if !srv.allowRegistration(clientHost, "PROXYB1", true) {
-		t.Fatal("different peer behind the same proxy should use a separate registration bucket")
+	for i := 0; i < 10; i++ {
+		if !srv.allowRegistration(clientHost, "PROXYA1", true) {
+			t.Fatalf("known peer heartbeat %d must not be rate limited", i+1)
+		}
 	}
 }
 

--- a/betterdesk-server/signal/server.go
+++ b/betterdesk-server/signal/server.go
@@ -725,41 +725,45 @@ func (s *Server) heartbeatCleaner() {
 			)
 
 			// Update database for peers that transitioned to DEGRADED
-			for _, id := range degraded {
-				if err := s.db.UpdatePeerStatus(id, "DEGRADED", ""); err != nil {
-					log.Printf("[signal] Failed to mark %s degraded: %v", id, err)
+			if len(degraded) > 0 {
+				if err := s.db.BatchUpdatePeerStatus(degraded, "DEGRADED"); err != nil {
+					log.Printf("[signal] Failed to mark %d peers degraded: %v", len(degraded), err)
 				}
-				log.Printf("[signal] Peer %s → DEGRADED (missed heartbeats)", id)
-				s.eventBus.Publish(events.Event{
-					Type: events.EventPeerDegraded,
-					Data: map[string]string{"id": id},
-				})
+				for _, id := range degraded {
+					log.Printf("[signal] Peer %s → DEGRADED (missed heartbeats)", id)
+					s.eventBus.Publish(events.Event{
+						Type: events.EventPeerDegraded,
+						Data: map[string]string{"id": id},
+					})
+				}
 			}
 
 			// Update database for peers that transitioned to CRITICAL
-			for _, id := range critical {
-				if err := s.db.UpdatePeerStatus(id, "CRITICAL", ""); err != nil {
-					log.Printf("[signal] Failed to mark %s critical: %v", id, err)
+			if len(critical) > 0 {
+				if err := s.db.BatchUpdatePeerStatus(critical, "CRITICAL"); err != nil {
+					log.Printf("[signal] Failed to mark %d peers critical: %v", len(critical), err)
 				}
-				log.Printf("[signal] Peer %s → CRITICAL (about to go offline)", id)
-				s.eventBus.Publish(events.Event{
-					Type: events.EventPeerCritical,
-					Data: map[string]string{"id": id},
-				})
+				for _, id := range critical {
+					log.Printf("[signal] Peer %s → CRITICAL (about to go offline)", id)
+					s.eventBus.Publish(events.Event{
+						Type: events.EventPeerCritical,
+						Data: map[string]string{"id": id},
+					})
+				}
 			}
 
 			// Phase 2: Remove fully expired peers (offline)
 			expired := s.peers.CleanExpired(config.RegTimeout)
-			for _, id := range expired {
-				if err := s.db.UpdatePeerStatus(id, "OFFLINE", ""); err != nil {
-					log.Printf("[signal] Failed to mark %s offline: %v", id, err)
-				}
-				s.eventBus.Publish(events.Event{
-					Type: events.EventPeerOffline,
-					Data: map[string]string{"id": id},
-				})
-			}
 			if len(expired) > 0 {
+				if err := s.db.BatchUpdatePeerStatus(expired, "OFFLINE"); err != nil {
+					log.Printf("[signal] Failed to mark %d peers offline: %v", len(expired), err)
+				}
+				for _, id := range expired {
+					s.eventBus.Publish(events.Event{
+						Type: events.EventPeerOffline,
+						Data: map[string]string{"id": id},
+					})
+				}
 				log.Printf("[signal] Cleaned %d expired peers (→ OFFLINE)", len(expired))
 			}
 		}


### PR DESCRIPTION
## Summary
- **CDAP:** `cleanupDeviceSessions` closes terminal, video, file, audio, and desktop sessions when a device disconnects.
- **DB/signal:** `BatchUpdatePeerStatus` replaces N+1 UPDATEs in heartbeat cleaner (DEGRADED/CRITICAL/OFFLINE).
- **Signal:** Known-peer heartbeats skip the registration IP limiter (less lock contention; targets stay online for RDClient/RustDesk).
- **Relay:** WebSocket relay applies the same per-IP `ConnLimiter` as TCP (RDClient uses TCP via Node proxy — unchanged).
- **Postgres:** 30s query timeout on peer status updates.
- **API:** Rate limit on `POST /api/org/login`.
- **CI:** New `go-server-ci.yml` — `go vet` + `go test -race` on `betterdesk-server/**` changes.

RustDesk/RDClient wire protocol unchanged (no punch/relay/RelayResponse semantics touched).

## Test plan
- [x] `cd betterdesk-server && go vet ./...`
- [x] `cd betterdesk-server && go test -race -count=1 ./...`
- [ ] Panel update on staging; RustDesk client connect + RDClient viewer smoke test
- [ ] CDAP device disconnect — no stale sessions in gateway