### PR TITLE
Go server maintenance wave 2: batch lookups, relay race fix, compat test

### DIFF
--- a/.github/workflows/go-server-ci.yml
+++ b/.github/workflows/go-server-ci.yml
@@ -1,0 +1,34 @@
+# BetterDesk Go server — vet + tests on push/PR
+name: Go Server CI
+
+on:
+  push:
+    branches: [main, dev]
+    paths:
+      - 'betterdesk-server/**'
+      - '.github/workflows/go-server-ci.yml'
+  pull_request:
+    paths:
+      - 'betterdesk-server/**'
+      - '.github/workflows/go-server-ci.yml'
+
+defaults:
+  run:
+    working-directory: betterdesk-server
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: betterdesk-server/go.mod
+          cache-dependency-path: betterdesk-server/go.sum
+
+      - name: go vet
+        run: go vet ./...
+
+      - name: go test
+        run: go test -race -count=1 ./...

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,15 @@
 ## [Unreleased]
 
 ### Changed
-- _(none yet)_
+
+- **Go server (performance):** batch peer lookup via `GetPeersByIDs` for address book merge and scoped RustDesk peer lists (avoids N+1 `GetPeer` queries on large fleets).
+- **Go server (billing):** stale pending relay metadata is swept after 10 minutes when pairing never completes.
+- **Go server (relay):** fix pairing race when both sides connect simultaneously (LoadOrStore instead of LoadAndDelete+Store).
+
+### Added
+
+- **Go server (compat):** integration test covering signal relay assignment through hbbr byte relay (`TestSignalRelayWireFlow`).
+- **Go server (tests):** relay pairing tests wait for `ActiveSessions` instead of a fixed sleep.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@
 ## [3.3.15] — 2026-06-14
 
 ### Changed
-- _(none yet)_
+
+- **Go server (stability):** CDAP disconnect cleans all session types (terminal, video, file, audio, desktop); batch peer status DB updates on mass offline; known-peer heartbeats skip registration rate limiter; relay WebSocket uses same per-IP ConnLimiter as TCP; Postgres query timeouts on status updates; org login rate limiting.
+- **CI:** `go-server-ci.yml` runs `go vet` and `go test -race` on changes under `betterdesk-server/`.
 
 ---
 

--- a/betterdesk-server/api/client_api_handlers.go
+++ b/betterdesk-server/api/client_api_handlers.go
@@ -608,9 +608,12 @@ func (s *Server) mergeAdminTagsIntoAB(data string) string {
 	adminTags := make(map[string][]string)
 	peerInfo := make(map[string]*db.Peer)
 	bannedPeers := make(map[string]bool)
-	for _, id := range ids {
-		peer, err := s.db.GetPeer(id)
-		if err != nil || peer == nil {
+	peerMap, err := s.db.GetPeersByIDs(ids)
+	if err != nil {
+		return data
+	}
+	for id, peer := range peerMap {
+		if peer == nil {
 			continue
 		}
 		// Issue #138: track banned/deleted peers so they can be stripped from the AB

--- a/betterdesk-server/api/org_handlers.go
+++ b/betterdesk-server/api/org_handlers.go
@@ -758,6 +758,12 @@ func (s *Server) handleSetOrgAddressBook(w http.ResponseWriter, r *http.Request)
 
 // POST /api/org/login
 func (s *Server) handleOrgLogin(w http.ResponseWriter, r *http.Request) {
+	clientIP := s.remoteIP(r)
+	if s.loginLimiter != nil && !s.loginLimiter.Allow(clientIP) {
+		http.Error(w, `{"error":"too many login attempts"}`, http.StatusTooManyRequests)
+		return
+	}
+
 	var body struct {
 		OrgSlug  string `json:"org_slug"`
 		OrgID    string `json:"org_id"`

--- a/betterdesk-server/api/rustdesk_peers.go
+++ b/betterdesk-server/api/rustdesk_peers.go
@@ -25,17 +25,39 @@ func (s *Server) buildRustDeskPeerList(r *http.Request) ([]map[string]any, int) 
 		return nil, 0
 	}
 
-	allPeers, err := s.db.ListPeers(false)
-	if err != nil {
-		return nil, 0
-	}
-
-	peerByID := make(map[string]*db.Peer, len(allPeers))
-	for _, p := range allPeers {
-		if p == nil || p.Banned || p.SoftDeleted || p.Disabled {
-			continue
+	var allowedIDs map[string]bool
+	peerByID := make(map[string]*db.Peer)
+	if !canBrowseRustDeskInventory(role) {
+		allowedIDs = s.addressBookPeerIDs(username)
+		if len(allowedIDs) == 0 {
+			return nil, 0
 		}
-		peerByID[p.ID] = p
+		ids := make([]string, 0, len(allowedIDs))
+		for id := range allowedIDs {
+			ids = append(ids, id)
+		}
+		peers, err := s.db.GetPeersByIDs(ids)
+		if err != nil {
+			return nil, 0
+		}
+		for id, p := range peers {
+			if p == nil || p.Banned || p.SoftDeleted || p.Disabled {
+				continue
+			}
+			peerByID[id] = p
+		}
+	} else {
+		allPeers, err := s.db.ListPeers(false)
+		if err != nil {
+			return nil, 0
+		}
+		peerByID = make(map[string]*db.Peer, len(allPeers))
+		for _, p := range allPeers {
+			if p == nil || p.Banned || p.SoftDeleted || p.Disabled {
+				continue
+			}
+			peerByID[p.ID] = p
+		}
 	}
 
 	folderAssignments := map[string]int64{}
@@ -60,9 +82,8 @@ func (s *Server) buildRustDeskPeerList(r *http.Request) ([]map[string]any, int) 
 
 	visiblePeer := s.rustDeskVisiblePeerSet(user, role, peerByID)
 	if !canBrowseRustDeskInventory(role) {
-		allowed := s.addressBookPeerIDs(username)
-		filtered := make(map[string]*db.Peer, len(allowed))
-		for id := range allowed {
+		filtered := make(map[string]*db.Peer, len(allowedIDs))
+		for id := range allowedIDs {
 			if p, ok := peerByID[id]; ok {
 				if visiblePeer == nil || visiblePeer[id] {
 					filtered[id] = p

--- a/betterdesk-server/billing/service.go
+++ b/betterdesk-server/billing/service.go
@@ -18,9 +18,9 @@ const (
 	PhaseIncluded = "included"
 	PhaseOverage  = "overage"
 
-	StatusActive         = "active"
-	StatusPendingReport  = "pending_report"
-	StatusClosed         = "closed"
+	StatusActive        = "active"
+	StatusPendingReport = "pending_report"
+	StatusClosed        = "closed"
 
 	ContractActive    = "active"
 	ContractSuspended = "suspended"
@@ -28,6 +28,8 @@ const (
 	LedgerSessionStart = "session_start"
 	LedgerPhaseChange  = "phase_change"
 	LedgerSessionEnd   = "session_end"
+
+	pendingRelayTTL = 10 * time.Minute
 )
 
 // ConnectionCheckResult is returned before allowing a remote session.
@@ -56,6 +58,7 @@ type pendingRelay struct {
 	OperatorID string
 	ContractID string
 	Currency   string
+	createdAt  time.Time
 }
 
 type activeSession struct {
@@ -101,6 +104,18 @@ func (s *Service) ticker(ctx context.Context) {
 			return
 		case <-tick.C:
 			s.tickActive()
+			s.sweepStalePending()
+		}
+	}
+}
+
+func (s *Service) sweepStalePending() {
+	cutoff := time.Now().Add(-pendingRelayTTL)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for uuid, meta := range s.pending {
+		if meta.createdAt.Before(cutoff) {
+			delete(s.pending, uuid)
 		}
 	}
 }
@@ -157,6 +172,7 @@ func (s *Service) PrepareRelay(relayUUID, deviceID, operatorID string) error {
 		OperatorID: operatorID,
 		ContractID: contract.ID,
 		Currency:   contract.Currency,
+		createdAt:  time.Now(),
 	}
 	s.mu.Unlock()
 	return nil

--- a/betterdesk-server/billing/service_test.go
+++ b/betterdesk-server/billing/service_test.go
@@ -17,6 +17,21 @@ func TestRoundUpMinutes(t *testing.T) {
 	}
 }
 
+func TestSweepStalePendingRelays(t *testing.T) {
+	svc := NewService(nil, nil, 1, false)
+	svc.pending["old"] = &pendingRelay{OrgID: "org1", createdAt: time.Now().Add(-11 * time.Minute)}
+	svc.pending["fresh"] = &pendingRelay{OrgID: "org1", createdAt: time.Now()}
+
+	svc.sweepStalePending()
+
+	if _, ok := svc.pending["old"]; ok {
+		t.Fatal("stale pending relay should be removed")
+	}
+	if _, ok := svc.pending["fresh"]; !ok {
+		t.Fatal("fresh pending relay should remain")
+	}
+}
+
 func TestOverageSplit(t *testing.T) {
 	remaining := 5
 	billed := 12

--- a/betterdesk-server/cdap/desktop.go
+++ b/betterdesk-server/cdap/desktop.go
@@ -367,13 +367,50 @@ func (g *Gateway) HandleDesktopInputError(ctx context.Context, _ *DeviceConn, ms
 }
 
 func (g *Gateway) cleanupDeviceSessions(deviceID, reason string) {
+	ctx := context.Background()
+
 	g.desktopSessions.Range(func(key, value any) bool {
 		ds, ok := value.(*DesktopSession)
 		if !ok || ds.DeviceID != deviceID {
 			return true
 		}
-		g.EndDesktopSession(context.Background(), ds.ID, reason)
-		g.desktopSessions.Delete(key)
+		g.EndDesktopSession(ctx, ds.ID, reason)
+		return true
+	})
+
+	g.terminalSessions.Range(func(key, value any) bool {
+		ts, ok := value.(*TerminalSession)
+		if !ok || ts.DeviceID != deviceID {
+			return true
+		}
+		g.EndTerminalSession(ctx, ts.ID, reason)
+		return true
+	})
+
+	g.videoSessions.Range(func(key, value any) bool {
+		vs, ok := value.(*VideoSession)
+		if !ok || vs.DeviceID != deviceID {
+			return true
+		}
+		g.EndVideoSession(ctx, vs.ID, reason)
+		return true
+	})
+
+	g.fileSessions.Range(func(key, value any) bool {
+		fs, ok := value.(*FileSession)
+		if !ok || fs.DeviceID != deviceID {
+			return true
+		}
+		g.EndFileSession(ctx, fs.ID, reason)
+		return true
+	})
+
+	g.audioSessions.Range(func(key, value any) bool {
+		as, ok := value.(*AudioSession)
+		if !ok || as.DeviceID != deviceID {
+			return true
+		}
+		g.EndAudioSession(ctx, as.ID, reason)
 		return true
 	})
 }

--- a/betterdesk-server/db/database.go
+++ b/betterdesk-server/db/database.go
@@ -412,6 +412,9 @@ type Database interface {
 
 	// Peer operations
 	GetPeer(id string) (*Peer, error)
+	// GetPeersByIDs returns active (non-soft-deleted) peers for the given IDs.
+	// Missing IDs are omitted; an empty ids slice returns an empty map.
+	GetPeersByIDs(ids []string) (map[string]*Peer, error)
 	GetPeerByUUID(uuid string) (*Peer, error)
 	UpsertPeer(p *Peer) error
 	DeletePeer(id string) error     // soft delete

--- a/betterdesk-server/db/database.go
+++ b/betterdesk-server/db/database.go
@@ -422,6 +422,7 @@ type Database interface {
 
 	// Status tracking
 	UpdatePeerStatus(id string, status string, ip string) error
+	BatchUpdatePeerStatus(ids []string, status string) error
 	UpdatePeerSysinfo(id, hostname, os, version string) error
 	SetAllOffline() error
 

--- a/betterdesk-server/db/postgres.go
+++ b/betterdesk-server/db/postgres.go
@@ -18,6 +18,8 @@ type PostgresDB struct {
 	pool *pgxpool.Pool
 	ctx  context.Context
 
+	queryTimeout time.Duration
+
 	// LISTEN/NOTIFY callback (nil = disabled). Set via OnNotify().
 	notifyFunc func(channel, payload string)
 }
@@ -55,7 +57,15 @@ func OpenPostgres(dsn string) (*PostgresDB, error) {
 		return nil, fmt.Errorf("db: PostgreSQL ping: %w", err)
 	}
 
-	return &PostgresDB{pool: pool, ctx: ctx}, nil
+	return &PostgresDB{pool: pool, ctx: ctx, queryTimeout: 30 * time.Second}, nil
+}
+
+// opCtx returns a context for database operations with optional query timeout.
+func (pg *PostgresDB) opCtx() (context.Context, context.CancelFunc) {
+	if pg.queryTimeout <= 0 {
+		return pg.ctx, func() {}
+	}
+	return context.WithTimeout(pg.ctx, pg.queryTimeout)
 }
 
 // Close closes the connection pool.
@@ -753,9 +763,24 @@ func (pg *PostgresDB) GetBannedPeerCount() (int, error) {
 
 // UpdatePeerStatus updates a peer's status and IP, plus last_online timestamp.
 func (pg *PostgresDB) UpdatePeerStatus(id string, status string, ip string) error {
-	_, err := pg.pool.Exec(pg.ctx,
+	ctx, cancel := pg.opCtx()
+	defer cancel()
+	_, err := pg.pool.Exec(ctx,
 		`UPDATE peers SET status = $1, ip = $2, last_online = NOW() WHERE id = $3 AND soft_deleted = FALSE`,
 		status, ip, id)
+	return err
+}
+
+// BatchUpdatePeerStatus sets status for many peers in one query.
+func (pg *PostgresDB) BatchUpdatePeerStatus(ids []string, status string) error {
+	if len(ids) == 0 {
+		return nil
+	}
+	ctx, cancel := pg.opCtx()
+	defer cancel()
+	_, err := pg.pool.Exec(ctx,
+		`UPDATE peers SET status = $1, last_online = NOW() WHERE soft_deleted = FALSE AND id = ANY($2)`,
+		status, ids)
 	return err
 }
 

--- a/betterdesk-server/db/postgres.go
+++ b/betterdesk-server/db/postgres.go
@@ -651,6 +651,30 @@ func (pg *PostgresDB) GetPeer(id string) (*Peer, error) {
 	return p, nil
 }
 
+// GetPeersByIDs returns active peers for the given IDs in one query.
+func (pg *PostgresDB) GetPeersByIDs(ids []string) (map[string]*Peer, error) {
+	if len(ids) == 0 {
+		return map[string]*Peer{}, nil
+	}
+
+	rows, err := pg.pool.Query(pg.ctx,
+		`SELECT `+peerColumns+` FROM peers WHERE soft_deleted = FALSE AND id = ANY($1)`, ids)
+	if err != nil {
+		return nil, fmt.Errorf("db: GetPeersByIDs: %w", err)
+	}
+	defer rows.Close()
+
+	peers, err := scanPeerRows(rows)
+	if err != nil {
+		return nil, fmt.Errorf("db: GetPeersByIDs: %w", err)
+	}
+	out := make(map[string]*Peer, len(peers))
+	for _, p := range peers {
+		out[p.ID] = p
+	}
+	return out, nil
+}
+
 // GetPeerByUUID returns a peer by UUID, or nil if not found.
 func (pg *PostgresDB) GetPeerByUUID(uuid string) (*Peer, error) {
 	row := pg.pool.QueryRow(pg.ctx,

--- a/betterdesk-server/db/sqlite.go
+++ b/betterdesk-server/db/sqlite.go
@@ -757,6 +757,29 @@ func (s *SQLiteDB) UpdatePeerStatus(id string, status string, ip string) error {
 	return err
 }
 
+// BatchUpdatePeerStatus sets status for many peers in one query (empty ip preserved).
+func (s *SQLiteDB) BatchUpdatePeerStatus(ids []string, status string) error {
+	if len(ids) == 0 {
+		return nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	placeholders := make([]string, len(ids))
+	args := make([]any, 0, len(ids)+1)
+	args = append(args, status)
+	for i, id := range ids {
+		placeholders[i] = "?"
+		args = append(args, id)
+	}
+	query := fmt.Sprintf(
+		`UPDATE peers SET status = ?, last_online = datetime('now') WHERE soft_deleted = 0 AND id IN (%s)`,
+		strings.Join(placeholders, ","),
+	)
+	_, err := s.db.Exec(query, args...)
+	return err
+}
+
 // UpdatePeerSysinfo updates hostname, os, and version for a peer.
 // Only non-empty values overwrite existing data.
 func (s *SQLiteDB) UpdatePeerSysinfo(id, hostname, os, version string) error {

--- a/betterdesk-server/db/sqlite.go
+++ b/betterdesk-server/db/sqlite.go
@@ -602,6 +602,62 @@ func (s *SQLiteDB) GetPeer(id string) (*Peer, error) {
 	return p, nil
 }
 
+// GetPeersByIDs returns active peers for the given IDs in one query.
+func (s *SQLiteDB) GetPeersByIDs(ids []string) (map[string]*Peer, error) {
+	if len(ids) == 0 {
+		return map[string]*Peer{}, nil
+	}
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	placeholders := make([]string, len(ids))
+	args := make([]any, len(ids))
+	for i, id := range ids {
+		placeholders[i] = "?"
+		args[i] = id
+	}
+	query := fmt.Sprintf(`SELECT id, uuid, pk, ip, user, hostname, os, version,
+	                  status, nat_type, last_online, created_at,
+	                  disabled, banned, ban_reason, banned_at,
+	                  soft_deleted, deleted_at, note, tags, heartbeat_seq,
+	                  device_type, linked_peer_id, display_name
+	           FROM peers
+	           WHERE (soft_deleted IS NULL OR soft_deleted = 0) AND id IN (%s)`,
+		strings.Join(placeholders, ","))
+
+	rows, err := s.db.Query(query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("db: GetPeersByIDs: %w", err)
+	}
+	defer rows.Close()
+
+	out := make(map[string]*Peer, len(ids))
+	for rows.Next() {
+		p := &Peer{}
+		var lastOnline, createdAt, bannedAt, deletedAt sql.NullString
+		if err := rows.Scan(
+			&p.ID, &p.UUID, &p.PK, &p.IP, &p.User, &p.Hostname,
+			&p.OS, &p.Version, &p.Status, &p.NATType,
+			&lastOnline, &createdAt, &p.Disabled, &p.Banned,
+			&p.BanReason, &bannedAt, &p.SoftDeleted, &deletedAt,
+			&p.Note, &p.Tags, &p.HeartbeatSeq,
+			&p.DeviceType, &p.LinkedPeerID, &p.DisplayName,
+		); err != nil {
+			return nil, fmt.Errorf("db: GetPeersByIDs scan: %w", err)
+		}
+		p.LastOnline = parseTime(lastOnline)
+		p.CreatedAt = parseTime(createdAt)
+		p.BannedAt = parseTimePtr(bannedAt)
+		p.DeletedAt = parseTimePtr(deletedAt)
+		out[p.ID] = p
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("db: GetPeersByIDs: %w", err)
+	}
+	return out, nil
+}
+
 // GetPeerByUUID returns a peer by UUID, or nil if not found.
 func (s *SQLiteDB) GetPeerByUUID(uuid string) (*Peer, error) {
 	s.mu.RLock()

--- a/betterdesk-server/db/sqlite_test.go
+++ b/betterdesk-server/db/sqlite_test.go
@@ -278,6 +278,47 @@ func TestBatchUpdatePeerStatus(t *testing.T) {
 	check("BATCH2", "DEGRADED")
 }
 
+func TestGetPeersByIDs(t *testing.T) {
+	db := newTestDB(t)
+
+	for _, id := range []string{"GPID1", "GPID2", "GPID3"} {
+		if err := db.UpsertPeer(&Peer{ID: id, Status: "ONLINE", Tags: id}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := db.DeletePeer("GPID3"); err != nil {
+		t.Fatal(err)
+	}
+
+	peers, err := db.GetPeersByIDs([]string{"GPID1", "GPID2", "GPID3", "MISSING"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(peers) != 2 {
+		t.Fatalf("GetPeersByIDs len = %d, want 2", len(peers))
+	}
+	if peers["GPID1"] == nil || peers["GPID2"] == nil {
+		t.Fatal("expected GPID1 and GPID2")
+	}
+	if peers["GPID1"].Tags != "GPID1" {
+		t.Fatalf("GPID1 tags = %q", peers["GPID1"].Tags)
+	}
+	if _, ok := peers["GPID3"]; ok {
+		t.Fatal("soft-deleted GPID3 must be omitted")
+	}
+	if _, ok := peers["MISSING"]; ok {
+		t.Fatal("missing ID must be omitted")
+	}
+
+	empty, err := db.GetPeersByIDs(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(empty) != 0 {
+		t.Fatalf("empty ids should return empty map, got %d", len(empty))
+	}
+}
+
 func TestBatchUpdatePeerStatusIgnoresSoftDeleted(t *testing.T) {
 	db := newTestDB(t)
 	if err := db.UpsertPeer(&Peer{ID: "BATCHDEL", Status: "ONLINE"}); err != nil {

--- a/betterdesk-server/db/sqlite_test.go
+++ b/betterdesk-server/db/sqlite_test.go
@@ -248,6 +248,58 @@ func TestUpdatePeerStatusIgnoresSoftDeleted(t *testing.T) {
 	}
 }
 
+func TestBatchUpdatePeerStatus(t *testing.T) {
+	db := newTestDB(t)
+
+	for _, id := range []string{"BATCH1", "BATCH2"} {
+		if err := db.UpsertPeer(&Peer{ID: id, Status: "ONLINE", IP: "10.0.0.1"}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if err := db.BatchUpdatePeerStatus([]string{"BATCH1", "BATCH2", "MISSING1"}, "DEGRADED"); err != nil {
+		t.Fatal(err)
+	}
+
+	check := func(id, wantStatus string) {
+		t.Helper()
+		p, err := db.GetPeer(id)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if p == nil {
+			t.Fatalf("peer %s not found", id)
+		}
+		if p.Status != wantStatus {
+			t.Fatalf("peer %s status = %q, want %q", id, p.Status, wantStatus)
+		}
+	}
+	check("BATCH1", "DEGRADED")
+	check("BATCH2", "DEGRADED")
+}
+
+func TestBatchUpdatePeerStatusIgnoresSoftDeleted(t *testing.T) {
+	db := newTestDB(t)
+	if err := db.UpsertPeer(&Peer{ID: "BATCHDEL", Status: "ONLINE"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.DeletePeer("BATCHDEL"); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.BatchUpdatePeerStatus([]string{"BATCHDEL"}, "CRITICAL"); err != nil {
+		t.Fatal(err)
+	}
+	peers, err := db.ListPeers(true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, p := range peers {
+		if p.ID == "BATCHDEL" && p.Status == "CRITICAL" {
+			t.Fatal("BatchUpdatePeerStatus must not update soft-deleted peer")
+		}
+	}
+}
+
 func TestBanSystem(t *testing.T) {
 	db := newTestDB(t)
 

--- a/betterdesk-server/relay/server.go
+++ b/betterdesk-server/relay/server.go
@@ -197,37 +197,41 @@ func (s *Server) handleConn(conn net.Conn) {
 	}
 
 	log.Printf("[relay] Connection from %s for UUID %s", conn.RemoteAddr(), uuid)
+	s.pairIncomingConn(conn, uuid)
+}
 
-	// Try to find a pending connection with the same UUID
-	if val, loaded := s.pending.LoadAndDelete(uuid); loaded {
-		// Found a pair — start relaying
-		pc := val.(*pendingConn)
-		close(pc.done) // signal that pairing succeeded
-		s.startRelay(pc.conn, conn, uuid)
-		return
-	}
-
-	// No pair yet — register as pending and wait
+// pairIncomingConn pairs two relay connections sharing the same session UUID.
+// LoadOrStore avoids a race where simultaneous connections both miss LoadAndDelete
+// and overwrite each other in pending without ever pairing.
+func (s *Server) pairIncomingConn(conn net.Conn, uuid string) {
 	pc := &pendingConn{
 		conn:    conn,
-		created: time.Now(),
+		created: timeNow(),
 		done:    make(chan struct{}),
 	}
-	s.pending.Store(uuid, pc)
 
-	// Wait for pair or timeout
+	if val, loaded := s.pending.LoadOrStore(uuid, pc); loaded {
+		existing := val.(*pendingConn)
+		s.pending.Delete(uuid)
+		close(existing.done)
+		s.startRelay(existing.conn, conn, uuid)
+		return
+	}
+
 	select {
 	case <-pc.done:
-		// Paired — the pairing goroutine handles relay
 		return
-	case <-time.After(config.RelayPairTimeout):
-		// Timeout — remove from pending and close
-		s.pending.Delete(uuid)
-		log.Printf("[relay] Pair timeout for UUID %s", uuid)
-		conn.Close()
+	case <-timeAfter(config.RelayPairTimeout):
+		if val, ok := s.pending.Load(uuid); ok && val.(*pendingConn) == pc {
+			s.pending.Delete(uuid)
+			conn.Close()
+			log.Printf("[relay] Pair timeout for UUID %s", uuid)
+		}
 	case <-s.ctx.Done():
-		s.pending.Delete(uuid)
-		conn.Close()
+		if val, ok := s.pending.Load(uuid); ok && val.(*pendingConn) == pc {
+			s.pending.Delete(uuid)
+			conn.Close()
+		}
 	}
 }
 

--- a/betterdesk-server/relay/server_test.go
+++ b/betterdesk-server/relay/server_test.go
@@ -11,6 +11,18 @@ import (
 	pb "github.com/unitronix/betterdesk-server/proto"
 )
 
+func waitRelayPairing(t *testing.T, srv *Server) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if srv.ActiveSessions.Load() >= 1 {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("relay pairing did not complete within 3s, active sessions = %d", srv.ActiveSessions.Load())
+}
+
 func TestRelayPairing(t *testing.T) {
 	cfg := config.DefaultConfig()
 	cfg.RelayPort = 0 // let OS pick a free port
@@ -81,7 +93,7 @@ func TestRelayPairing(t *testing.T) {
 	// RelayResponse confirmation — it immediately starts transparent
 	// bidirectional byte copy after pairing (sending RelayResponse would
 	// break the E2E encryption handshake in production).
-	time.Sleep(500 * time.Millisecond)
+	waitRelayPairing(t, srv)
 
 	// Test bidirectional data relay (no confirmation message expected)
 	testData := []byte("Hello from A to B!")
@@ -122,6 +134,52 @@ func TestRelayPairing(t *testing.T) {
 	if srv.TotalRelayed.Load() != 1 {
 		t.Errorf("total relayed: got %d, want 1", srv.TotalRelayed.Load())
 	}
+}
+
+func TestRelaySimultaneousPairing(t *testing.T) {
+	cfg := config.DefaultConfig()
+	ln, err := net.Listen("tcp", ":0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+	ln.Close()
+
+	cfg.RelayPort = port
+	srv := New(cfg)
+	if err := srv.Start(t.Context()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer srv.Stop()
+
+	uuid := "simul-pair-uuid-789"
+	addr := fmt.Sprintf("127.0.0.1:%d", port)
+	dialAndRequest := func(id string) net.Conn {
+		conn, err := net.DialTimeout("tcp", addr, 5*time.Second)
+		if err != nil {
+			t.Fatalf("dial %s: %v", id, err)
+		}
+		req := &pb.RendezvousMessage{
+			Union: &pb.RendezvousMessage_RequestRelay{
+				RequestRelay: &pb.RequestRelay{Uuid: uuid, Id: id},
+			},
+		}
+		if err := codec.WriteRawProto(conn, req); err != nil {
+			t.Fatalf("write %s: %v", id, err)
+		}
+		return conn
+	}
+
+	done := make(chan net.Conn, 2)
+	go func() { done <- dialAndRequest("PEER_A") }()
+	go func() { done <- dialAndRequest("PEER_B") }()
+
+	connA := <-done
+	connB := <-done
+	defer connA.Close()
+	defer connB.Close()
+
+	waitRelayPairing(t, srv)
 }
 
 func TestRelayHealthCheck(t *testing.T) {

--- a/betterdesk-server/relay/ws.go
+++ b/betterdesk-server/relay/ws.go
@@ -63,6 +63,19 @@ func (s *Server) serveWS() {
 // After upgrade, the first binary frame must be a RequestRelay (with UUID).
 // Then we convert the WS to a net.Conn and feed it into the existing pairing logic.
 func (s *Server) handleWSRelayUpgrade(w http.ResponseWriter, r *http.Request) {
+	ip, _, _ := net.SplitHostPort(r.RemoteAddr)
+	if ip == "" {
+		ip = r.RemoteAddr
+	}
+	if s.connLimiter != nil && !s.connLimiter.Acquire(ip) {
+		log.Printf("[relay] WS connection rejected from %s (per-IP limit exceeded)", ip)
+		http.Error(w, "too many connections", http.StatusServiceUnavailable)
+		return
+	}
+	if s.connLimiter != nil {
+		defer s.connLimiter.Release(ip)
+	}
+
 	opts := &websocket.AcceptOptions{}
 
 	// Secure-by-default origin validation:

--- a/betterdesk-server/relay/ws.go
+++ b/betterdesk-server/relay/ws.go
@@ -154,33 +154,7 @@ func isLoopbackOrigin(origin string) bool {
 
 // pairWSConn pairs a WebSocket-derived net.Conn using the same UUID logic as TCP.
 func (s *Server) pairWSConn(conn net.Conn, uuid string) {
-	// Try to find a pending connection with same UUID
-	if val, loaded := s.pending.LoadAndDelete(uuid); loaded {
-		pc := val.(*pendingConn)
-		close(pc.done)
-		s.startRelay(pc.conn, conn, uuid)
-		return
-	}
-
-	// No pair yet — register as pending and wait
-	pc := &pendingConn{
-		conn:    conn,
-		created: timeNow(),
-		done:    make(chan struct{}),
-	}
-	s.pending.Store(uuid, pc)
-
-	select {
-	case <-pc.done:
-		return
-	case <-timeAfter(config.RelayPairTimeout):
-		s.pending.Delete(uuid)
-		log.Printf("[relay] WS pair timeout for UUID %s", uuid)
-		conn.Close()
-	case <-s.ctx.Done():
-		s.pending.Delete(uuid)
-		conn.Close()
-	}
+	s.pairIncomingConn(conn, uuid)
 }
 
 // NOTE: confirmRelay was removed — the RustDesk client does not expect

--- a/betterdesk-server/signal/compat_flow_test.go
+++ b/betterdesk-server/signal/compat_flow_test.go
@@ -1,0 +1,116 @@
+package signal
+
+import (
+	"fmt"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/unitronix/betterdesk-server/codec"
+	"github.com/unitronix/betterdesk-server/config"
+	"github.com/unitronix/betterdesk-server/peer"
+	pb "github.com/unitronix/betterdesk-server/proto"
+	"github.com/unitronix/betterdesk-server/relay"
+)
+
+// TestSignalRelayWireFlow verifies signal relay assignment plus hbbr byte relay
+// without changing the RustDesk wire protocol (no RelayResponse after pairing).
+func TestSignalRelayWireFlow(t *testing.T) {
+	cfgRelay := config.DefaultConfig()
+	ln, err := net.Listen("tcp", ":0")
+	if err != nil {
+		t.Fatalf("listen relay: %v", err)
+	}
+	relayPort := ln.Addr().(*net.TCPAddr).Port
+	ln.Close()
+
+	cfgRelay.RelayPort = relayPort
+	relaySrv := relay.New(cfgRelay)
+	if err := relaySrv.Start(t.Context()); err != nil {
+		t.Fatalf("relay Start: %v", err)
+	}
+	defer relaySrv.Stop()
+
+	srv, _ := newTestSignalServer(t, config.EnrollmentModeOpen)
+	srv.cfg.RelayServers = fmt.Sprintf("127.0.0.1:%d", relayPort)
+	srv.localIP.Store("127.0.0.1")
+
+	relayUUID := "compat-flow-relay-uuid-001"
+	srv.peers.Put(&peer.Entry{
+		ID:         "COMPATGT",
+		ConnType:   peer.ConnTCP,
+		LastReg:    time.Now(),
+		StatusTier: peer.StatusOnline,
+	})
+
+	resp := srv.handleRequestRelayTCP(&pb.RequestRelay{
+		Id:   "COMPATGT",
+		Uuid: relayUUID,
+	}, udpAddr("127.0.0.1", 52002))
+	if resp == nil {
+		t.Fatal("handleRequestRelayTCP returned nil")
+	}
+	rr := resp.GetRelayResponse()
+	if rr == nil {
+		t.Fatalf("expected RelayResponse, got %+v", resp)
+	}
+	if rr.Uuid != relayUUID {
+		t.Fatalf("relay uuid = %q, want %q", rr.Uuid, relayUUID)
+	}
+
+	relayAddr := fmt.Sprintf("127.0.0.1:%d", relayPort)
+	connA, err := net.DialTimeout("tcp", relayAddr, 5*time.Second)
+	if err != nil {
+		t.Fatalf("dial relay A: %v", err)
+	}
+	defer connA.Close()
+	connB, err := net.DialTimeout("tcp", relayAddr, 5*time.Second)
+	if err != nil {
+		t.Fatalf("dial relay B: %v", err)
+	}
+	defer connB.Close()
+
+	reqA := &pb.RendezvousMessage{
+		Union: &pb.RendezvousMessage_RequestRelay{
+			RequestRelay: &pb.RequestRelay{Uuid: relayUUID, Id: "COMPATGT"},
+		},
+	}
+	reqB := &pb.RendezvousMessage{
+		Union: &pb.RendezvousMessage_RequestRelay{
+			RequestRelay: &pb.RequestRelay{Uuid: relayUUID, Id: "COMPATINIT"},
+		},
+	}
+	if err := codec.WriteRawProto(connA, reqA); err != nil {
+		t.Fatalf("write relay A: %v", err)
+	}
+	if err := codec.WriteRawProto(connB, reqB); err != nil {
+		t.Fatalf("write relay B: %v", err)
+	}
+
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if relaySrv.ActiveSessions.Load() >= 1 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if relaySrv.ActiveSessions.Load() != 1 {
+		t.Fatalf("relay pairing did not complete, active sessions = %d", relaySrv.ActiveSessions.Load())
+	}
+
+	payload := []byte("compat-flow-payload")
+	connA.SetWriteDeadline(time.Now().Add(5 * time.Second))
+	if _, err := connA.Write(payload); err != nil {
+		t.Fatalf("write payload: %v", err)
+	}
+
+	buf := make([]byte, len(payload))
+	connB.SetReadDeadline(time.Now().Add(5 * time.Second))
+	n, err := connB.Read(buf)
+	if err != nil {
+		t.Fatalf("read payload: %v", err)
+	}
+	if string(buf[:n]) != string(payload) {
+		t.Fatalf("payload = %q, want %q", buf[:n], payload)
+	}
+}

--- a/betterdesk-server/signal/handler.go
+++ b/betterdesk-server/signal/handler.go
@@ -79,13 +79,15 @@ func (s *Server) publishPeerOnline(id string) {
 }
 
 func (s *Server) allowRegistration(clientHost, peerID string, knownPeer bool) bool {
+	// Registered peers send heartbeats every ~12s — rate-limiting those adds
+	// lock contention without abuse benefit (peer ID is already validated in memory).
+	if knownPeer {
+		return true
+	}
 	if s.limiter == nil {
 		return true
 	}
-	if !knownPeer {
-		return s.limiter.Allow(signalLimiterKey("reg-new", clientHost, ""))
-	}
-	return s.limiter.Allow(signalLimiterKey("reg", clientHost, peerID))
+	return s.limiter.Allow(signalLimiterKey("reg-new", clientHost, ""))
 }
 
 func (s *Server) allowSignalConnection(clientHost string) bool {

--- a/betterdesk-server/signal/handler_test.go
+++ b/betterdesk-server/signal/handler_test.go
@@ -164,24 +164,17 @@ func TestHandleRegisterPeerWSRejectsSoftDeletedHeartbeat(t *testing.T) {
 	}
 }
 
-func TestRegistrationLimiterUsesPeerScopedBucket(t *testing.T) {
+func TestRegistrationLimiterSkipsKnownPeerHeartbeats(t *testing.T) {
 	srv, _ := newTestSignalServer(t, config.EnrollmentModeOpen)
 	limiter := ratelimit.NewIPLimiter(2, time.Minute, time.Minute)
 	t.Cleanup(limiter.Stop)
 	srv.SetRateLimiter(limiter)
 
 	clientHost := "172.29.1.20"
-	if !srv.allowRegistration(clientHost, "PROXYA1", true) {
-		t.Fatal("first registration for PROXYA1 should be allowed")
-	}
-	if !srv.allowRegistration(clientHost, "PROXYA1", true) {
-		t.Fatal("second registration for PROXYA1 should be allowed")
-	}
-	if srv.allowRegistration(clientHost, "PROXYA1", true) {
-		t.Fatal("third registration for the same peer should be rate limited")
-	}
-	if !srv.allowRegistration(clientHost, "PROXYB1", true) {
-		t.Fatal("different peer behind the same proxy should use a separate registration bucket")
+	for i := 0; i < 10; i++ {
+		if !srv.allowRegistration(clientHost, "PROXYA1", true) {
+			t.Fatalf("known peer heartbeat %d must not be rate limited", i+1)
+		}
 	}
 }
 

--- a/betterdesk-server/signal/server.go
+++ b/betterdesk-server/signal/server.go
@@ -725,41 +725,45 @@ func (s *Server) heartbeatCleaner() {
 			)
 
 			// Update database for peers that transitioned to DEGRADED
-			for _, id := range degraded {
-				if err := s.db.UpdatePeerStatus(id, "DEGRADED", ""); err != nil {
-					log.Printf("[signal] Failed to mark %s degraded: %v", id, err)
+			if len(degraded) > 0 {
+				if err := s.db.BatchUpdatePeerStatus(degraded, "DEGRADED"); err != nil {
+					log.Printf("[signal] Failed to mark %d peers degraded: %v", len(degraded), err)
 				}
-				log.Printf("[signal] Peer %s → DEGRADED (missed heartbeats)", id)
-				s.eventBus.Publish(events.Event{
-					Type: events.EventPeerDegraded,
-					Data: map[string]string{"id": id},
-				})
+				for _, id := range degraded {
+					log.Printf("[signal] Peer %s → DEGRADED (missed heartbeats)", id)
+					s.eventBus.Publish(events.Event{
+						Type: events.EventPeerDegraded,
+						Data: map[string]string{"id": id},
+					})
+				}
 			}
 
 			// Update database for peers that transitioned to CRITICAL
-			for _, id := range critical {
-				if err := s.db.UpdatePeerStatus(id, "CRITICAL", ""); err != nil {
-					log.Printf("[signal] Failed to mark %s critical: %v", id, err)
+			if len(critical) > 0 {
+				if err := s.db.BatchUpdatePeerStatus(critical, "CRITICAL"); err != nil {
+					log.Printf("[signal] Failed to mark %d peers critical: %v", len(critical), err)
 				}
-				log.Printf("[signal] Peer %s → CRITICAL (about to go offline)", id)
-				s.eventBus.Publish(events.Event{
-					Type: events.EventPeerCritical,
-					Data: map[string]string{"id": id},
-				})
+				for _, id := range critical {
+					log.Printf("[signal] Peer %s → CRITICAL (about to go offline)", id)
+					s.eventBus.Publish(events.Event{
+						Type: events.EventPeerCritical,
+						Data: map[string]string{"id": id},
+					})
+				}
 			}
 
 			// Phase 2: Remove fully expired peers (offline)
 			expired := s.peers.CleanExpired(config.RegTimeout)
-			for _, id := range expired {
-				if err := s.db.UpdatePeerStatus(id, "OFFLINE", ""); err != nil {
-					log.Printf("[signal] Failed to mark %s offline: %v", id, err)
-				}
-				s.eventBus.Publish(events.Event{
-					Type: events.EventPeerOffline,
-					Data: map[string]string{"id": id},
-				})
-			}
 			if len(expired) > 0 {
+				if err := s.db.BatchUpdatePeerStatus(expired, "OFFLINE"); err != nil {
+					log.Printf("[signal] Failed to mark %d peers offline: %v", len(expired), err)
+				}
+				for _, id := range expired {
+					s.eventBus.Publish(events.Event{
+						Type: events.EventPeerOffline,
+						Data: map[string]string{"id": id},
+					})
+				}
 				log.Printf("[signal] Cleaned %d expired peers (→ OFFLINE)", len(expired))
 			}
 		}


### PR DESCRIPTION
## Summary

Wave 2 of Go server maintenance (builds on wave 1 in #201 — both commits are on this branch):

- **`GetPeersByIDs`** — batch DB lookup for address book merge and scoped RustDesk peer lists (removes N+1 `GetPeer` on large fleets)
- **Billing** — sweep stale pending relay metadata after 10 minutes when pairing never completes
- **Relay pairing race fix** — `LoadOrStore` pairing so simultaneous connections cannot overwrite each other in `pending` without pairing (TCP + WS)
- **Compat test** — `TestSignalRelayWireFlow` (signal relay assignment → hbbr byte relay)
- **Test stability** — relay tests wait on `ActiveSessions`; `TestRelaySimultaneousPairing` covers the race

Wave 1 (same branch, #201): CDAP session cleanup, batch peer status updates, heartbeat rate-limit skip, relay WS ConnLimiter, Postgres query timeouts, org login rate limit, Go CI workflow.

## Test plan

- [x] `cd betterdesk-server && go test -race -count=1 ./...`
- [ ] After merge to dev: panel update on test server; verify RustDesk client + RDClient relay sessions still connect
- [ ] Large fleet: address book sync and scoped peer list should remain correct with fewer DB round-trips

## Notes

If #201 merges first, rebase this branch onto `dev` before merge to avoid duplicate wave-1 commits in history.