### PR TITLE
fix(rdclient): correct WebSocket relay framing and file sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## [Unreleased]
 
+### Fixed
+- **Browser Remote Desktop over relay WSS:** send raw RustDesk protobuf
+  payloads as native WebSocket messages and translate framing only in the
+  optional Node TCP bridge, including mixed browser-WebSocket/desktop-TCP
+  sessions.
+
 ### Changed
 - _(none yet)_
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## [Unreleased]
 
 ### Fixed
+- **Browser file transfer on legacy viewer layouts:** lazy-load the dedicated
+  file relay and compression runtime, wait for the file-transfer session before
+  browsing, and report connection failures through the UI.
 - **Browser Remote Desktop over relay WSS:** send raw RustDesk protobuf
   payloads as native WebSocket messages and translate framing only in the
   optional Node TCP bridge, including mixed browser-WebSocket/desktop-TCP

--- a/web-nodejs/public/js/rdclient/client.js
+++ b/web-nodejs/public/js/rdclient/client.js
@@ -1688,7 +1688,10 @@ class RDClient {
             this._peerEncoding = info.encoding;
         }
         this._windowsSessions = this._parseWindowsSessions(info);
-        if (this.input && info.platform) {
+        // Older 3.3.2 console images ship the legacy RDInput implementation.
+        // Peer platform is an input enhancement, not a reason to abort a
+        // successful login when the optional setter is unavailable.
+        if (this.input && info.platform && typeof this.input.setPeerPlatform === 'function') {
             this.input.setPeerPlatform(info.platform);
         }
     }
@@ -1746,14 +1749,18 @@ class RDClient {
      * Release stuck remote modifiers / keys (toolbar recovery).
      */
     resetKeyboard() {
-        if (this.input) this.input.resetKeyboard();
+        if (this.input && typeof this.input.resetKeyboard === 'function') {
+            this.input.resetKeyboard();
+        }
     }
 
     /**
      * @param {'Legacy'|'Map'|'Auto'} mode
      */
     setKeyboardMode(mode) {
-        if (this.input) this.input.setKeyboardMode(mode);
+        if (this.input && typeof this.input.setKeyboardMode === 'function') {
+            this.input.setKeyboardMode(mode);
+        }
     }
 
     /**

--- a/web-nodejs/public/js/rdclient/client.js
+++ b/web-nodejs/public/js/rdclient/client.js
@@ -41,6 +41,7 @@ class RDClient {
         this.renderer = new RDRenderer(canvas);
         this.input = new RDInput(canvas, this.renderer, (msg) => this._sendPeerMessage(msg));
         this._fileConnection = null;
+        this._fileTransferRuntimePromise = null;
         this._sessionPassword = '';
         this.fileTransfer = new RDFileTransfer({
             proto: this.proto,
@@ -269,13 +270,61 @@ class RDClient {
         return !!(this._fileConnection && this._fileConnection.state === 'ready');
     }
 
-    async ensureFileConnection() {
-        if (typeof RDFileConnection !== 'function') {
-            throw new Error('File transfer module not loaded');
+    _loadRuntimeScript(path, ready) {
+        if (ready()) return Promise.resolve();
+        if (typeof document === 'undefined' || !document.head) {
+            return Promise.reject(new Error('File transfer runtime is unavailable'));
         }
+
+        return new Promise((resolve, reject) => {
+            const existing = document.querySelector('script[data-rd-runtime="' + path + '"]');
+            const script = existing || document.createElement('script');
+            const finish = () => ready()
+                ? resolve()
+                : reject(new Error('Could not load ' + path));
+
+            script.addEventListener('load', finish, { once: true });
+            script.addEventListener('error', () => reject(new Error('Could not load ' + path)), { once: true });
+            if (existing) return;
+
+            const clientScript = Array.from(document.scripts || []).find((node) =>
+                node.src && node.src.includes('/js/rdclient/client.js')
+            );
+            let versionQuery = '';
+            if (clientScript && clientScript.src) {
+                try { versionQuery = new URL(clientScript.src, window.location.href).search; }
+                catch (_e) { versionQuery = ''; }
+            }
+            script.src = path + versionQuery;
+            script.async = false;
+            script.dataset.rdRuntime = path;
+            document.head.appendChild(script);
+        });
+    }
+
+    _loadFileTransferRuntime() {
+        const hasConnection = () => typeof window !== 'undefined'
+            && typeof window.RDFileConnection === 'function';
+        const hasCompression = () => typeof window !== 'undefined'
+            && typeof window.RDCompress === 'function';
+        if (hasConnection() && hasCompression()) return Promise.resolve();
+        if (this._fileTransferRuntimePromise) return this._fileTransferRuntimePromise;
+
+        this._fileTransferRuntimePromise = Promise.resolve()
+            .then(() => this._loadRuntimeScript('/js/rdclient/compress.js', hasCompression))
+            .then(() => this._loadRuntimeScript('/js/rdclient/file-connection.js', hasConnection))
+            .catch((err) => {
+                this._fileTransferRuntimePromise = null;
+                throw err;
+            });
+        return this._fileTransferRuntimePromise;
+    }
+
+    async ensureFileConnection() {
+        await this._loadFileTransferRuntime();
         if (!this.proto.loaded) await this.proto.load();
         if (!this._fileConnection) {
-            this._fileConnection = new RDFileConnection({
+            this._fileConnection = new window.RDFileConnection({
                 deviceId: this.deviceId,
                 serverPubKey: this.opts.serverPubKey || '',
                 myName: this.opts.myName || 'BetterDesk Web',

--- a/web-nodejs/public/js/rdclient/client.js
+++ b/web-nodejs/public/js/rdclient/client.js
@@ -58,9 +58,9 @@ class RDClient {
         this._pingInterval = null;
         this._statsInterval = null;
 
-        // Stream decoders for RustDesk variable-length frame codec (TCP reassembly)
+        // Rendezvous is bridged to TCP and needs BytesCodec reassembly. Relay
+        // uses native WebSocket message framing (one raw payload per message).
         this._rendezvousDecoder = null;
-        this._relayDecoder = null;
 
         // Codec / quality control
         this._codecAbilities = null;          // probed VideoDecoder support map
@@ -72,7 +72,7 @@ class RDClient {
 
         // Relay state tracking
         this._relayFrameIdx = 0;         // Counter for relay frames (debugging)
-        this._relayConfirmReceived = false; // Whether hbbr's RelayResponse confirmation was consumed
+        this._relayConfirmReceived = false; // First relay frame checked for legacy injected confirmation
         this._peerEncryptionConfirmed = false; // Whether peer has started encrypting
         this._keyExchangePending = false;  // True when we have keys ready but haven't sent PublicKey yet
         this._keyExchangeDone = false;     // True after PublicKey was sent and crypto enabled
@@ -150,7 +150,6 @@ class RDClient {
 
             // Step 3: Create stream decoders for TCP frame reassembly
             this._rendezvousDecoder = this.proto.createStreamDecoder();
-            this._relayDecoder = this.proto.createStreamDecoder();
 
             // Step 4: Connect to rendezvous server via WS proxy
             this._emit('log', 'Connecting to rendezvous server...');
@@ -248,7 +247,7 @@ class RDClient {
                 relayServer,
                 this.opts.serverPubKey
             );
-            const relayData = this.proto.encodeRendezvous(requestRelay);
+            const relayData = this.proto.serializeRendezvous(requestRelay);
             this.conn.sendRelay(relayData);
 
             // Step 13: Wait for target's SignedId (first message from relay)
@@ -592,22 +591,18 @@ class RDClient {
     }
 
     /**
-     * Handle raw incoming relay data (TCP chunks via WebSocket)
-     * Uses stream decoder for frame reassembly, then dispatches each complete message.
+     * Handle one raw RustDesk payload from the native relay WebSocket.
      *
-     * After hbbr pairs both peers (by UUID), the relay operates in raw mode — just
-     * bridging TCP bytes. However, the FIRST framed message from hbbr is a
-     * RendezvousMessage.RelayResponse confirmation (not a peer Message).
-     * We detect and skip it, then process all subsequent frames as peer Messages.
+     * WebSocket message boundaries replace TCP BytesCodec framing. Mixed
+     * WebSocket/TCP relay sessions are translated by hbbr, so the browser must
+     * neither add nor attempt to decode a TCP length header.
      *
      * @param {ArrayBuffer} rawData
      */
     _handleRelayData(rawData) {
         try {
-            const frames = this._relayDecoder.feed(rawData);
-            for (const frame of frames) {
-                this._handleRelayMessage(frame);
-            }
+            const payload = rawData instanceof ArrayBuffer ? new Uint8Array(rawData) : new Uint8Array(rawData);
+            if (payload.length > 0) this._handleRelayMessage(payload);
         } catch (err) {
             console.warn('[RDClient] Error decoding relay data:', err.message);
         }
@@ -617,9 +612,9 @@ class RDClient {
      * Handle a single decoded relay frame (protobuf bytes).
      *
      * Frame sequence on a relay connection:
-     *   #1: hbbr RelayResponse confirmation (RendezvousMessage — skip this)
-     *   #2: Target's SignedId (Message, unencrypted)
-     *   #3+: Target's Hash, TestDelay etc. — may be plaintext OR encrypted
+     *   #1: Target's SignedId (Message, unencrypted). A legacy hbbr may inject
+     *       a RelayResponse first; tolerate and skip it if present.
+     *   #2+: Target's Hash, TestDelay etc. — may be plaintext OR encrypted
      *        depending on whether the target has processed our PublicKey yet
      *   #N:  Once peer encryption is confirmed, all subsequent frames are encrypted
      *
@@ -631,7 +626,7 @@ class RDClient {
      *     happen since we haven’t sent it yet in this flow) or peer uses some
      *     other encryption setup — handled via speculative decrypt.
      *
-     * @param {Uint8Array} frameData - Raw protobuf bytes (frame header already stripped)
+     * @param {Uint8Array} frameData - Raw protobuf bytes from one WS message
      */
     _handleRelayMessage(frameData) {
         try {
@@ -643,8 +638,8 @@ class RDClient {
                 this._debugRelay(`[RDClient] Relay frame #${idx}: ${frameData.length} bytes [${hex20}]`);
             }
 
-            // The relay server (hbbr) sends a RendezvousMessage.RelayResponse
-            // as the first frame after pairing both peers.  Skip it.
+            // Official hbbr sends the target's SignedId first. Tolerate older
+            // servers that injected a RendezvousMessage.RelayResponse.
             if (!this._relayConfirmReceived) {
                 this._relayConfirmReceived = true;
                 try {
@@ -1380,7 +1375,7 @@ class RDClient {
 
     /**
      * Send a peer-to-peer message through the relay
-     * Order: serialize protobuf → encrypt (if enabled) → frame → send
+     * Order: serialize protobuf → encrypt (if enabled) → send as one WS message
      * @param {Object} msgObj - Message object (will be encoded as Message protobuf)
      */
     _sendPeerMessage(msgObj) {
@@ -1394,11 +1389,8 @@ class RDClient {
             data = this.crypto.processOutgoing(data);
         }
 
-        // Step 3: Add frame header to the (possibly encrypted) bytes
-        const framed = this.proto.frameBytes(data);
-
-        // Step 4: Send over relay WebSocket
-        this.conn.sendRelay(framed);
+        // Native relay WebSocket framing carries one raw payload per message.
+        this.conn.sendRelay(data);
     }
 
     // ---- State & Cleanup ----
@@ -1460,9 +1452,6 @@ class RDClient {
         this._sessionPassword = '';
         this.conn.close();
         this._codecFallbackDone = false;
-        if (this._relayDecoder) {
-            this._relayDecoder.reset();
-        }
         if (this._rendezvousDecoder) {
             this._rendezvousDecoder.reset();
         }

--- a/web-nodejs/public/js/rdclient/compress.js
+++ b/web-nodejs/public/js/rdclient/compress.js
@@ -94,3 +94,7 @@ class RDCompress {
         return { content: raw, compress: false };
     }
 }
+
+if (typeof window !== 'undefined') {
+    window.RDCompress = RDCompress;
+}

--- a/web-nodejs/public/js/rdclient/connection.js
+++ b/web-nodejs/public/js/rdclient/connection.js
@@ -123,7 +123,12 @@ class RDConnection {
     connectRelay() {
         return new Promise((resolve, reject) => {
             this._setState('relay');
-            const url = `${this.wsBase}/ws/relay${this._guestQuerySuffix()}`;
+            // Native hbbr WebSocket framing: one raw RustDesk payload per WS
+            // binary message. The query also lets the optional Node TCP bridge
+            // translate BytesCodec framing when a reverse proxy does not route
+            // /ws/relay directly to hbbr WSS.
+            const guestQuery = this._guestQuerySuffix();
+            const url = `${this.wsBase}/ws/relay${guestQuery}${guestQuery ? '&' : '?'}transport=message`;
 
             const ws = new WebSocket(url);
             ws.binaryType = 'arraybuffer';

--- a/web-nodejs/public/js/rdclient/file-connection.js
+++ b/web-nodejs/public/js/rdclient/file-connection.js
@@ -24,7 +24,6 @@ class RDFileConnection {
         this._state = 'idle'; // idle | connecting | authenticating | ready | error | disconnected
         this._listeners = {};
         this._rendezvousDecoder = null;
-        this._relayDecoder = null;
         this._relayConfirmReceived = false;
         this._keyExchangePending = false;
         this._keyExchangeDone = false;
@@ -111,7 +110,6 @@ class RDFileConnection {
             if (!this.proto.loaded) await this.proto.load();
 
             this._rendezvousDecoder = this.proto.createStreamDecoder();
-            this._relayDecoder = this.proto.createStreamDecoder();
             this._relayConfirmReceived = false;
             this._keyExchangePending = false;
             this._keyExchangeDone = false;
@@ -165,7 +163,7 @@ class RDFileConnection {
                 }
             });
 
-            const relayData = this.proto.encodeRendezvous(
+            const relayData = this.proto.serializeRendezvous(
                 this.proto.buildRequestRelay(
                     this.deviceId, relayUUID, relayServer, this.opts.serverPubKey, ct
                 )
@@ -236,7 +234,7 @@ class RDFileConnection {
         if (this.crypto.enabled) {
             data = this.crypto.processOutgoing(data);
         }
-        this.conn.sendRelay(this.proto.frameBytes(data));
+        this.conn.sendRelay(data);
     }
 
     disconnect() {
@@ -351,10 +349,8 @@ class RDFileConnection {
 
     _handleRelayData(rawData) {
         try {
-            const frames = this._relayDecoder.feed(rawData);
-            for (const frame of frames) {
-                this._handleRelayMessage(frame);
-            }
+            const payload = rawData instanceof ArrayBuffer ? new Uint8Array(rawData) : new Uint8Array(rawData);
+            if (payload.length > 0) this._handleRelayMessage(payload);
         } catch (err) {
             console.warn('[RDFileConnection] relay decode:', err.message);
         }
@@ -490,7 +486,7 @@ class RDFileConnection {
     _sendPeerMessageRaw(msgObj) {
         let data = this.proto.serializeMessage(msgObj);
         if (this.crypto.enabled) data = this.crypto.processOutgoing(data);
-        this.conn.sendRelay(this.proto.frameBytes(data));
+        this.conn.sendRelay(data);
     }
 
     _handleLoginResponse(resp) {

--- a/web-nodejs/public/js/rdclient/protocol.js
+++ b/web-nodejs/public/js/rdclient/protocol.js
@@ -99,9 +99,17 @@ class RDProtocol {
      * (used for direct rendezvous communication, no encryption)
      */
     encodeRendezvous(msgObj) {
+        return this._encodeFrame(this.serializeRendezvous(msgObj));
+    }
+
+    /**
+     * Serialize a RendezvousMessage without a TCP BytesCodec header.
+     * Native RustDesk WebSocket endpoints use one protobuf payload per binary
+     * WebSocket message and therefore must not receive TCP framing.
+     */
+    serializeRendezvous(msgObj) {
         const msg = this.types.RendezvousMessage.create(msgObj);
-        const buf = this.types.RendezvousMessage.encode(msg).finish();
-        return this._encodeFrame(buf);
+        return this.types.RendezvousMessage.encode(msg).finish();
     }
 
     /**

--- a/web-nodejs/services/wsRelay.js
+++ b/web-nodejs/services/wsRelay.js
@@ -22,9 +22,97 @@ const { registerUpgradeHandler } = require('./wsUpgradeRouter');
 const MAX_CONNECTIONS_PER_IP = 5;
 // Connection timeout (no data for 2 minutes = close)
 const IDLE_TIMEOUT_MS = 120000;
+// RustDesk allows large encoded desktop frames on relay connections.
+const MAX_RELAY_FRAME_SIZE = 64 * 1024 * 1024;
 
 // Track connections per IP
 const connectionsPerIp = new Map();
+
+/** Encode one raw WebSocket message as a RustDesk BytesCodec TCP frame. */
+function encodeRelayFrame(data) {
+    const payload = Buffer.isBuffer(data) ? data : Buffer.from(data);
+    const len = payload.length;
+    if (len <= 0 || len > MAX_RELAY_FRAME_SIZE) {
+        throw new Error(`invalid relay frame size: ${len}`);
+    }
+
+    let header;
+    if (len <= 0x3F) {
+        header = Buffer.from([len << 2]);
+    } else if (len <= 0x3FFF) {
+        header = Buffer.allocUnsafe(2);
+        header.writeUInt16LE((len << 2) | 0x01);
+    } else if (len <= 0x3FFFFF) {
+        const value = (len * 4) + 0x02;
+        header = Buffer.allocUnsafe(3);
+        header[0] = value & 0xFF;
+        header[1] = (value >>> 8) & 0xFF;
+        header[2] = (value >>> 16) & 0xFF;
+    } else {
+        header = Buffer.allocUnsafe(4);
+        header.writeUInt32LE(((len * 4) + 0x03) >>> 0);
+    }
+    return Buffer.concat([header, payload], header.length + len);
+}
+
+/**
+ * Decode arbitrary TCP chunks into complete RustDesk BytesCodec payloads.
+ * The returned payloads are copies because the backing buffer is reused.
+ */
+function createRelayFrameDecoder() {
+    let buffer = Buffer.alloc(0);
+    let dataLen = 0;
+
+    return {
+        feed(chunk) {
+            const incoming = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+            const needed = dataLen + incoming.length;
+            if (needed > MAX_RELAY_FRAME_SIZE + 4) {
+                throw new Error('relay frame buffer exceeds maximum size');
+            }
+            if (needed > buffer.length) {
+                const capacity = Math.min(
+                    MAX_RELAY_FRAME_SIZE + 4,
+                    Math.max(needed, buffer.length * 2, 4096)
+                );
+                const grown = Buffer.allocUnsafe(capacity);
+                if (dataLen > 0) buffer.copy(grown, 0, 0, dataLen);
+                buffer = grown;
+            }
+            incoming.copy(buffer, dataLen);
+            dataLen += incoming.length;
+
+            const frames = [];
+            let offset = 0;
+            while (offset < dataLen) {
+                const headerLen = (buffer[offset] & 0x03) + 1;
+                if (dataLen - offset < headerLen) break;
+
+                let encoded = 0;
+                for (let i = 0; i < headerLen; i++) {
+                    encoded += buffer[offset + i] * (2 ** (8 * i));
+                }
+                const payloadLen = Math.floor(encoded / 4);
+                if (payloadLen <= 0 || payloadLen > MAX_RELAY_FRAME_SIZE) {
+                    throw new Error(`invalid relay payload length: ${payloadLen}`);
+                }
+                if (dataLen - offset - headerLen < payloadLen) break;
+
+                const start = offset + headerLen;
+                frames.push(Buffer.from(buffer.subarray(start, start + payloadLen)));
+                offset = start + payloadLen;
+            }
+
+            if (offset > 0) {
+                const remaining = dataLen - offset;
+                if (remaining > 0) buffer.copy(buffer, 0, offset, dataLen);
+                dataLen = remaining;
+            }
+            if (dataLen === 0 && buffer.length > 1024 * 1024) buffer = Buffer.alloc(0);
+            return frames;
+        }
+    };
+}
 
 /**
  * Check if a hostname resolves to a loopback address
@@ -153,10 +241,15 @@ function initWsProxy(server, sessionMiddleware) {
 
                     if (pathname === '/ws/rendezvous') {
                         rendezvousWss.handleUpgrade(request, socket, head, (ws) => {
+                            ws._betterdeskMessageTransport = false;
                             rendezvousWss.emit('connection', ws, request);
                         });
                     } else {
                         relayWss.handleUpgrade(request, socket, head, (ws) => {
+                            // Browser RdClient uses native WebSocket message framing.
+                            // If this request reaches the Node TCP bridge, translate
+                            // each WS message to/from RustDesk BytesCodec frames.
+                            ws._betterdeskMessageTransport = url.searchParams.get('transport') === 'message';
                             relayWss.emit('connection', ws, request);
                         });
                     }
@@ -191,7 +284,9 @@ function initWsProxy(server, sessionMiddleware) {
 
     // Relay connections
     relayWss.on('connection', (ws, req) => {
-        handleProxyConnection(ws, req, hbbrHost, hbbrPort, 'relay');
+        handleProxyConnection(ws, req, hbbrHost, hbbrPort, 'relay', {
+            messageTransport: ws._betterdeskMessageTransport === true
+        });
     });
 
     console.log(`  WebSocket proxy: /ws/rendezvous -> ${hbbsHost}:${hbbsPort}`);
@@ -203,7 +298,7 @@ function initWsProxy(server, sessionMiddleware) {
 /**
  * Handle a single proxied WebSocket connection
  */
-function handleProxyConnection(ws, req, targetHost, targetPort, label) {
+function handleProxyConnection(ws, req, targetHost, targetPort, label, options = {}) {
     const clientIp = req.headers['x-forwarded-for']?.split(',')[0]?.trim()
         || req.socket.remoteAddress
         || 'unknown';
@@ -219,6 +314,8 @@ function handleProxyConnection(ws, req, targetHost, targetPort, label) {
 
     // Idle timeout
     let idleTimer = null;
+    const messageTransport = options.messageTransport === true;
+    const relayDecoder = messageTransport ? createRelayFrameDecoder() : null;
     const resetIdleTimer = () => {
         if (idleTimer) clearTimeout(idleTimer);
         idleTimer = setTimeout(() => {
@@ -245,7 +342,18 @@ function handleProxyConnection(ws, req, targetHost, targetPort, label) {
     tcp.on('data', (data) => {
         resetIdleTimer();
         if (ws.readyState === WebSocket.OPEN) {
-            ws.send(data);
+            if (!messageTransport) {
+                ws.send(data);
+                return;
+            }
+            try {
+                for (const payload of relayDecoder.feed(data)) {
+                    ws.send(payload, { binary: true });
+                }
+            } catch (err) {
+                console.error(`WS proxy [${label}]: invalid relay TCP frame:`, err.message);
+                cleanup();
+            }
         }
     });
 
@@ -255,7 +363,13 @@ function handleProxyConnection(ws, req, targetHost, targetPort, label) {
         if (!tcp.destroyed) {
             // Ensure we send Buffer, not string
             const buf = Buffer.isBuffer(data) ? data : Buffer.from(data);
-            tcp.write(buf);
+            if (messageTransport && buf.length === 0) return;
+            try {
+                tcp.write(messageTransport ? encodeRelayFrame(buf) : buf);
+            } catch (err) {
+                console.error(`WS proxy [${label}]: invalid relay WS frame:`, err.message);
+                cleanup();
+            }
         }
     });
 
@@ -292,4 +406,8 @@ function handleProxyConnection(ws, req, targetHost, targetPort, label) {
     }
 }
 
-module.exports = { initWsProxy };
+module.exports = {
+    initWsProxy,
+    // Exported for deterministic framing tests; not part of the HTTP API.
+    _relayFraming: { encodeRelayFrame, createRelayFrameDecoder, MAX_RELAY_FRAME_SIZE }
+};

--- a/web-nodejs/tests/filetransfer.logic.test.js
+++ b/web-nodejs/tests/filetransfer.logic.test.js
@@ -50,3 +50,50 @@ describe('RDFileTransfer overwrite strategy', () => {
         expect(ft._pendingOverwrite.has(1)).toBe(false);
     });
 });
+
+describe('RDFileTransfer dedicated connection', () => {
+    it('waits for the file relay before sending a directory request', async () => {
+        let resolveConnection;
+        const ensureConnected = jest.fn(() => new Promise(resolve => { resolveConnection = resolve; }));
+        const sendMessage = jest.fn();
+        const emit = jest.fn();
+        const ft = new RDFileTransfer({
+            proto: { buildReadDir: (path, showHidden) => ({ readDir: { path, showHidden } }) },
+            sendMessage,
+            emit,
+            ensureConnected,
+            isConnected: () => false,
+        });
+        ft.enable();
+
+        ft.browseDir('C:\\Users');
+        expect(ensureConnected).toHaveBeenCalledTimes(1);
+        expect(sendMessage).not.toHaveBeenCalled();
+        expect(emit).toHaveBeenCalledWith('file_connecting');
+
+        resolveConnection();
+        await new Promise(resolve => setImmediate(resolve));
+
+        expect(sendMessage).toHaveBeenCalledWith({
+            readDir: { path: 'C:\\Users', showHidden: false }
+        });
+        clearTimeout(ft._browseTimeout);
+    });
+
+    it('reports connection errors instead of throwing from the click handler', async () => {
+        const emit = jest.fn();
+        const ft = new RDFileTransfer({
+            proto: { buildReadDir: jest.fn() },
+            sendMessage: jest.fn(),
+            emit,
+            ensureConnected: () => Promise.reject(new Error('relay unavailable')),
+            isConnected: () => false,
+        });
+        ft.enable();
+
+        expect(() => ft.browseDir('')).not.toThrow();
+        await new Promise(resolve => setImmediate(resolve));
+
+        expect(emit).toHaveBeenCalledWith('file_connect_error', { error: 'relay unavailable' });
+    });
+});

--- a/web-nodejs/tests/rdclient.relayTransport.test.js
+++ b/web-nodejs/tests/rdclient.relayTransport.test.js
@@ -98,6 +98,19 @@ describe('RDClient raw relay messages', () => {
         expect(client._handleRelayMessage).toHaveBeenCalledTimes(1);
         expect(Array.from(client._handleRelayMessage.mock.calls[0][0])).toEqual(Array.from(raw));
     });
+
+    it('accepts PeerInfo with the legacy 3.3.2 input implementation', () => {
+        const RDClient = loadBrowserScript('public/js/rdclient/client.js').RDClient;
+        const client = Object.create(RDClient.prototype);
+        client.input = {}; // Legacy RDInput has no platform/mode helper methods.
+        client._parseVirtualDisplaySupport = jest.fn(() => ({ supported: false }));
+        client._parseWindowsSessions = jest.fn(() => ({ sessions: [], currentSid: 0 }));
+
+        expect(() => client._processPeerInfo({ platform: 'Windows', currentDisplay: 0 })).not.toThrow();
+        expect(() => client.resetKeyboard()).not.toThrow();
+        expect(() => client.setKeyboardMode('Auto')).not.toThrow();
+        expect(client._currentDisplay).toBe(0);
+    });
 });
 
 describe('RDFileConnection raw relay messages', () => {

--- a/web-nodejs/tests/rdclient.relayTransport.test.js
+++ b/web-nodejs/tests/rdclient.relayTransport.test.js
@@ -111,6 +111,47 @@ describe('RDClient raw relay messages', () => {
         expect(() => client.setKeyboardMode('Auto')).not.toThrow();
         expect(client._currentDisplay).toBe(0);
     });
+
+    it('lazy-loads dedicated file-transfer dependencies for legacy viewer layouts', async () => {
+        const appended = [];
+        let sandbox;
+        const document = {
+            scripts: [{ src: 'https://console.example.test/js/rdclient/client.js?v=runtime-42' }],
+            querySelector: () => null,
+            createElement: () => {
+                const handlers = {};
+                return {
+                    dataset: {},
+                    addEventListener(type, fn) { handlers[type] = fn; },
+                    _dispatch(type) { if (handlers[type]) handlers[type](); },
+                };
+            },
+            head: {
+                appendChild(script) {
+                    appended.push(script.src);
+                    if (script.src.includes('/compress.js')) sandbox.RDCompress = function RDCompress() {};
+                    if (script.src.includes('/file-connection.js')) sandbox.RDFileConnection = function RDFileConnection() {};
+                    script._dispatch('load');
+                },
+            },
+        };
+        sandbox = loadBrowserScript('public/js/rdclient/client.js', {
+            document,
+            location: { href: 'https://console.example.test/remote/device' },
+            URL,
+        });
+        const client = Object.create(sandbox.RDClient.prototype);
+        client._fileTransferRuntimePromise = null;
+
+        await client._loadFileTransferRuntime();
+
+        expect(appended).toEqual([
+            '/js/rdclient/compress.js?v=runtime-42',
+            '/js/rdclient/file-connection.js?v=runtime-42',
+        ]);
+        expect(typeof sandbox.RDCompress).toBe('function');
+        expect(typeof sandbox.RDFileConnection).toBe('function');
+    });
 });
 
 describe('RDFileConnection raw relay messages', () => {

--- a/web-nodejs/tests/rdclient.relayTransport.test.js
+++ b/web-nodejs/tests/rdclient.relayTransport.test.js
@@ -1,0 +1,120 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const protobuf = require('protobufjs');
+
+function loadBrowserScript(relativePath, globals = {}) {
+    const sandbox = {
+        console,
+        Uint8Array,
+        ArrayBuffer,
+        ...globals,
+    };
+    sandbox.window = sandbox;
+    sandbox.globalThis = sandbox;
+    const filename = path.join(__dirname, '..', relativePath);
+    vm.runInNewContext(fs.readFileSync(filename, 'utf8'), sandbox, { filename });
+    return sandbox;
+}
+
+describe('RDProtocol relay WebSocket serialization', () => {
+    let RDProtocol;
+    let RendezvousMessage;
+
+    beforeAll(async () => {
+        const root = await protobuf.load(path.join(__dirname, '../protos/rendezvous.proto'));
+        RendezvousMessage = root.lookupType('hbb.RendezvousMessage');
+        RDProtocol = loadBrowserScript('public/js/rdclient/protocol.js').RDProtocol;
+    });
+
+    it('keeps native WS payload raw while retaining TCP framing for rendezvous', () => {
+        const protocol = new RDProtocol();
+        protocol.types.RendezvousMessage = RendezvousMessage;
+        const message = { requestRelay: { id: 'target', uuid: 'relay-test-uuid' } };
+
+        const raw = protocol.serializeRendezvous(message);
+        const framed = protocol.encodeRendezvous(message);
+        const decodedFrames = protocol.createStreamDecoder().feed(framed);
+
+        expect(decodedFrames).toHaveLength(1);
+        expect(Buffer.from(decodedFrames[0]).equals(Buffer.from(raw))).toBe(true);
+        expect(RendezvousMessage.decode(raw).requestRelay.uuid).toBe('relay-test-uuid');
+        expect(Buffer.from(framed).equals(Buffer.from(raw))).toBe(false);
+    });
+});
+
+describe('RDConnection native relay WebSocket transport', () => {
+    it('selects message transport on the relay URL', async () => {
+        const sockets = [];
+        class MockWebSocket {
+            static OPEN = 1;
+            constructor(url) {
+                this.url = url;
+                sockets.push(this);
+            }
+        }
+        const sandbox = loadBrowserScript('public/js/rdclient/connection.js', {
+            location: { protocol: 'https:', host: 'console.example.test' },
+            WebSocket: MockWebSocket,
+        });
+        const connection = new sandbox.RDConnection();
+
+        const opening = connection.connectRelay();
+        expect(sockets[0].url).toBe('wss://console.example.test/ws/relay?transport=message');
+        sockets[0].onopen();
+        await expect(opening).resolves.toBe(sockets[0]);
+    });
+});
+
+describe('RDClient raw relay messages', () => {
+    it('sends encrypted-or-plain protobuf bytes without adding TCP framing', () => {
+        const RDClient = loadBrowserScript('public/js/rdclient/client.js').RDClient;
+        const client = Object.create(RDClient.prototype);
+        const raw = new Uint8Array([0x12, 0x01, 0x01]);
+        client.proto = {
+            loaded: true,
+            serializeMessage: jest.fn(() => raw),
+            frameBytes: jest.fn(() => { throw new Error('must not frame native WS messages'); }),
+        };
+        client.crypto = { enabled: false, processOutgoing: jest.fn() };
+        client.conn = { sendRelay: jest.fn() };
+
+        client._sendPeerMessage({ testDelay: { time: 1 } });
+
+        expect(client.proto.frameBytes).not.toHaveBeenCalled();
+        expect(client.conn.sendRelay).toHaveBeenCalledWith(raw);
+    });
+
+    it('treats each incoming WS message as exactly one relay payload', () => {
+        const RDClient = loadBrowserScript('public/js/rdclient/client.js').RDClient;
+        const client = Object.create(RDClient.prototype);
+        client._handleRelayMessage = jest.fn();
+        const raw = new Uint8Array([0x0a, 0x01, 0x01]);
+
+        client._handleRelayData(raw.buffer);
+
+        expect(client._handleRelayMessage).toHaveBeenCalledTimes(1);
+        expect(Array.from(client._handleRelayMessage.mock.calls[0][0])).toEqual(Array.from(raw));
+    });
+});
+
+describe('RDFileConnection raw relay messages', () => {
+    it('does not add TCP framing to file-transfer WS payloads', () => {
+        const RDFileConnection = loadBrowserScript('public/js/rdclient/file-connection.js').RDFileConnection;
+        const connection = Object.create(RDFileConnection.prototype);
+        const raw = new Uint8Array([0x22, 0x01, 0x01]);
+        connection.proto = {
+            serializeMessage: jest.fn(() => raw),
+            frameBytes: jest.fn(() => { throw new Error('must not frame native WS messages'); }),
+        };
+        connection.crypto = { enabled: false, processOutgoing: jest.fn() };
+        connection.conn = { sendRelay: jest.fn() };
+
+        connection._sendPeerMessageRaw({ fileAction: {} });
+
+        expect(connection.proto.frameBytes).not.toHaveBeenCalled();
+        expect(connection.conn.sendRelay).toHaveBeenCalledWith(raw);
+    });
+});

--- a/web-nodejs/tests/wsRelay.framing.test.js
+++ b/web-nodejs/tests/wsRelay.framing.test.js
@@ -1,0 +1,34 @@
+const { _relayFraming } = require('../services/wsRelay');
+
+describe('wsRelay RustDesk message/TCP framing bridge', () => {
+    test('round-trips fragmented BytesCodec frames at every header size', () => {
+        const sizes = [1, 63, 64, 16383, 16384, 0x400000];
+        const payloads = sizes.map((size, index) => Buffer.alloc(size, index + 1));
+        const stream = Buffer.concat(payloads.map(_relayFraming.encodeRelayFrame));
+        const decoder = _relayFraming.createRelayFrameDecoder();
+        const decoded = [];
+
+        // Deliberately split both headers and payloads across arbitrary TCP chunks.
+        const chunkSizes = [1, 2, 7, 31, 257, 4096, 65535];
+        let offset = 0;
+        let chunkIndex = 0;
+        while (offset < stream.length) {
+            const end = Math.min(stream.length, offset + chunkSizes[chunkIndex % chunkSizes.length]);
+            decoded.push(...decoder.feed(stream.subarray(offset, end)));
+            offset = end;
+            chunkIndex++;
+        }
+
+        expect(decoded).toHaveLength(payloads.length);
+        decoded.forEach((payload, index) => expect(payload.equals(payloads[index])).toBe(true));
+    });
+
+    test('rejects empty WebSocket payloads instead of emitting invalid TCP frames', () => {
+        expect(() => _relayFraming.encodeRelayFrame(Buffer.alloc(0))).toThrow('invalid relay frame size');
+    });
+
+    test('rejects an invalid zero-length TCP header', () => {
+        const decoder = _relayFraming.createRelayFrameDecoder();
+        expect(() => decoder.feed(Buffer.from([0]))).toThrow('invalid relay payload length');
+    });
+});

--- a/web-nodejs/tests/wsRelay.security.test.js
+++ b/web-nodejs/tests/wsRelay.security.test.js
@@ -138,7 +138,7 @@ describe('wsRelay — security: session validation on WS upgrade', () => {
         await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
         address = server.address();
 
-        const result = await rawUpgrade(address, '/ws/relay');
+        const result = await rawUpgrade(address, '/ws/relay?transport=message');
         expect(result.statusLine).toBe('HTTP/1.1 401 Unauthorized');
     });
 


### PR DESCRIPTION
## Summary

Fix the browser RdClient relay transport, legacy input compatibility and lazy file-transfer session initialization. The branch is rebased additively on the upstream `dev` (`3.5.11` at the last branch refresh).

This remains separate from the server-side WebSocket work in #348 so it can be reviewed or accepted independently.

## Changes

- Send raw RustDesk payloads as native WebSocket binary messages.
- Translate `BytesCodec` framing only when `/ws/relay` reaches the optional Node TCP bridge.
- Preserve mixed browser-WebSocket/desktop-TCP interoperability.
- Tolerate legacy input implementations that do not expose `setPeerPlatform`.
- Lazy-load the dedicated file relay and compression runtime.
- Wait for the file-transfer relay session before browsing a directory.
- Surface file-transfer connection failures through the UI instead of throwing from click handlers.

## Additive upstream integration

Current `dev` introduced a shared WebSocket upgrade router and explicit guest-token propagation after this PR was opened. The conflict resolution keeps both:

- `/ws/rendezvous` and `/ws/relay` remain registered through the shared router;
- authenticated operator sessions and guest query/cookie checks remain enforced;
- `connectRelay()` preserves `?guest=...` and appends `transport=message` with the correct query separator;
- only relay upgrades opt into the Node framing translator.

## Reverse proxy behavior

Our deployment uses nginx, but the code does not require one specific external proxy.

Two supported routes are explicit:

1. route `/ws/relay` directly to hbbr WSS — complete WebSocket message boundaries remain native;
2. route `/ws/relay` to the BetterDesk Node console — `transport=message` makes the Node TCP bridge convert each WS message to/from one RustDesk `BytesCodec` frame.

The second path is useful when an external proxy terminates WSS at the console instead of routing a separate hbbr WSS upstream. Standard WebSocket Upgrade/Connection forwarding and normal origin/session controls still apply.

## Validation

```bash
npm test -- --runInBand \
  tests/rdclient.relayTransport.test.js \
  tests/wsRelay.framing.test.js \
  tests/wsRelay.security.test.js \
  tests/filetransfer.logic.test.js
```

Result: 24/24 tests passed after the rebase.

Coverage includes:

- native relay message transport;
- arbitrary TCP chunk splitting/coalescing through the `BytesCodec` decoder;
- authenticated upgrade rejection paths on the shared router;
- legacy input fallback;
- lazy file relay and browse-directory readiness.

## Security

- Existing authenticated session, guest-token and origin checks for WebSocket upgrades remain enabled.
- Relay frame parsing is explicitly size-bounded.
- No deployment domains, IP addresses, credentials, keys or private configuration are included.

## Dependency note

The browser-side code is independently reviewable. End-to-end mixed WebSocket/native desktop relay uses the complementary server framing bridge from #348.