### PR TITLE
hotfix: open issues remediation (3.4.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 ## [Unreleased]
 
 ### Changed
+- _(none yet)_
+
+### Fixed
+- _(none yet)_
+
+---
+
+## [3.4.3] — 2026-07-30
+
+
+### Changed
 - **Client Configuration public key masked by default (#319):** Dashboard and Keys page show the KEY as bullets until revealed via an eye toggle; Copy still pastes the raw key. Ships via panel update.
 - **Docker update channel (#299):** Settings → Updates cannot switch stable/dev for GHCR image installs; use `BETTERDESK_IMAGE_TAG=latest` or `dev`, then `docker compose pull && up -d`. Panel shows a clear note; API returns `DOCKER_IMAGE_CHANNEL`.
 


### PR DESCRIPTION
## Summary
- Promotes CHANGELOG `[Unreleased]` into `3.4.3` so the main version-bump workflow can cut a patch release.
- Code already on `main`: OIDC `user.info` (#326), viewer-only outbound (#327), pending_device hardening (#302), Docker channel UX (#299), Caddy docs (#294), plus prior Unreleased fixes (#315/#319/#320/#321/#323/#325).

## Test plan
- [ ] CI green on this PR
- [ ] After merge: tag `v3.4.3` + GitHub Release created by Version Bump workflow
- [ ] Panel update / verify comments already posted on linked issues