### PR TITLE
docs: sync sponsors list (Redspin, MyNameisStitch) to dev

### DIFF
--- a/.cursor/rules/sponsors-update.mdc
+++ b/.cursor/rules/sponsors-update.mdc
@@ -1,0 +1,24 @@
+---
+description: Update SPONSORS.md immediately when a new supporter donates; push to main
+alwaysApply: true
+---
+
+# Sponsors — update the project immediately
+
+When the operator reports a new BetterDesk supporter (Buy Me a Coffee, GitHub Sponsors, honorary, or similar):
+
+1. **Update [`SPONSORS.md`](SPONSORS.md) in the same session** — do not defer or wait for a release.
+2. Place the entry in the correct section:
+   - **Individual Backers** — one-time BMC / small personal donations (same pattern as existing entries).
+   - **Honorary Supporters** — significant non-monetary or special recognition (also update README badge when applicable).
+   - GitHub Sponsors **Bronze+** — follow tier perks in `SPONSORS.md` (logo/README as required).
+3. Use the supporter’s preferred public name; link GitHub when known. Mention relevant issues only if they contributed a useful report.
+4. Bump `*Last updated:*` at the bottom of `SPONSORS.md`.
+5. **Commit and push to `main`** (or the branch the operator names) so the list is public promptly — sponsors are not “dev-only” docs.
+6. Do **not** imply Commercial Grant for Buy Me a Coffee or $5/$15 GitHub tiers (see [`docs/COMMERCIAL-GRANT.md`](docs/COMMERCIAL-GRANT.md)).
+
+## Checklist
+
+- [ ] Entry added under the right heading in `SPONSORS.md`
+- [ ] `Last updated` date refreshed
+- [ ] Committed and pushed to the public default/`main` path the operator requested

--- a/SPONSORS.md
+++ b/SPONSORS.md
@@ -41,6 +41,15 @@ support and for believing in open, self-hostable remote-management software.
 
 Thank you, Marco! 🙏
 
+### MyNameisStitch ([@MyNameisStitch](https://github.com/MyNameisStitch))
+
+**MyNameisStitch** backed BetterDesk with a generous donation via
+[Buy Me a Coffee](https://buymeacoffee.com/unitronix), and contributed a
+detailed Web Remote / reverse-proxy report that helped clarify documentation
+for other operators ([#329](https://github.com/UNITRONIX/BetterDesk/issues/329)).
+
+Thank you, MyNameisStitch! 🙏
+
 ---
 
 ## 💖 How to Sponsor
@@ -183,4 +192,4 @@ belongs to the creator.
 
 ---
 
-*Last updated: 2026-06-13*
+*Last updated: 2026-07-31*

--- a/SPONSORS.md
+++ b/SPONSORS.md
@@ -50,6 +50,14 @@ for other operators ([#329](https://github.com/UNITRONIX/BetterDesk/issues/329))
 
 Thank you, MyNameisStitch! 🙏
 
+### Redspin (@playerumpknow)
+
+**Redspin** backed BetterDesk with a generous donation via
+[Buy Me a Coffee](https://buymeacoffee.com/unitronix). We are grateful for the
+support and for believing in open, self-hostable remote-management software.
+
+Thank you, Redspin! 🙏
+
 ---
 
 ## 💖 How to Sponsor


### PR DESCRIPTION
﻿## Summary
- Bring SPONSORS.md Individual Backers (MyNameisStitch, Redspin) and the sponsors Cursor rule from main onto dev.
- Clears GitHub recent-push Compare and pull request nudges caused by pushing docs straight to main while default branch is dev.

## Test plan
- [ ] Confirm SPONSORS.md on dev lists both backers
- [ ] Yellow branch banners on the repo home page disappear (or after deleting leftover sync/main-to-dev-3.5.0)
