### PR TITLE
fix(relay, signal): bridge mixed transports and preserve ID renames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## [Unreleased]
 
+### Fixed
+- **Peer ID changes while connected (#213):** renaming a registered device now
+  preserves its live TCP/WSS transport, follows the renamed WSS identity for
+  heartbeats, and permits safe round-trip renames without treating the current
+  ID as stale history. Incoming sessions can reach the device immediately
+  after the rename, with SQLite and PostgreSQL behavior kept consistent.
+
 ### Changed
 - _(none yet)_
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 ## [Unreleased]
 
 ### Fixed
+- **Mixed WebSocket/native relay sessions (#290):** instead of rejecting a
+  WebSocket client paired with a native TCP/TLS client, the relay now translates
+  complete WebSocket binary messages to and from bounded RustDesk `BytesCodec`
+  frames. TCP/TCP remains a raw byte pipe and WebSocket/WebSocket retains the
+  large-message boundary preservation from #293.
 - **Peer ID changes while connected (#213):** renaming a registered device now
   preserves its live TCP/WSS transport, follows the renamed WSS identity for
   heartbeats, and permits safe round-trip renames without treating the current

--- a/betterdesk-server/api/server.go
+++ b/betterdesk-server/api/server.go
@@ -1381,12 +1381,10 @@ func (s *Server) handleChangePeerID(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Update memory map
-	entry := s.peers.Remove(oldID)
-	if entry != nil {
-		entry.ID = body.NewID
-		s.peers.Put(entry)
-	}
+	// Preserve the live TCP/WSS registration while changing its map key.
+	// Closing that connection makes the renamed device appear present in the
+	// management API but unreachable for inbound RustDesk sessions.
+	s.peers.Rename(oldID, body.NewID)
 
 	if s.auditLog != nil {
 		s.auditLog.Log(audit.ActionPeerIDChanged, s.remoteIP(r), oldID, map[string]string{"new_id": body.NewID})

--- a/betterdesk-server/codec/framing.go
+++ b/betterdesk-server/codec/framing.go
@@ -24,6 +24,11 @@ const (
 	// RustDesk messages are typically small; this prevents memory abuse.
 	MaxFrameSize = 64 * 1024
 
+	// RelayMaxFrameSize permits complete desktop/video messages while retaining
+	// a hard allocation bound for untrusted TCP frame headers. It matches the
+	// WebSocket relay message limit.
+	RelayMaxFrameSize = 16 * 1024 * 1024
+
 	// HeaderSize is the size of the legacy TCP frame header (2 bytes).
 	// Used only by internal framed communication, not RustDesk protocol.
 	HeaderSize = 2
@@ -149,8 +154,12 @@ func WriteRawProto(conn net.Conn, msg *pb.RendezvousMessage) error {
 
 // WriteRawBytes writes raw bytes with variable-length header to a TCP connection.
 func WriteRawBytes(conn net.Conn, data []byte) error {
-	if len(data) > MaxFrameSize {
-		return fmt.Errorf("codec: data too large (%d > %d)", len(data), MaxFrameSize)
+	return writeRawBytesLimit(conn, data, MaxFrameSize)
+}
+
+func writeRawBytesLimit(conn net.Conn, data []byte, maxFrameSize int) error {
+	if len(data) > maxFrameSize {
+		return fmt.Errorf("codec: data too large (%d > %d)", len(data), maxFrameSize)
 	}
 	header := encodeHeader(len(data))
 	frame := make([]byte, len(header)+len(data))
@@ -162,6 +171,10 @@ func WriteRawBytes(conn net.Conn, data []byte) error {
 
 // ReadRawBytes reads a variable-length-framed raw byte payload from a TCP connection.
 func ReadRawBytes(conn net.Conn, timeout time.Duration) ([]byte, error) {
+	return readRawBytesLimit(conn, timeout, MaxFrameSize)
+}
+
+func readRawBytesLimit(conn net.Conn, timeout time.Duration, maxFrameSize int) ([]byte, error) {
 	if timeout > 0 {
 		if err := conn.SetReadDeadline(time.Now().Add(timeout)); err != nil {
 			return nil, err
@@ -177,8 +190,8 @@ func ReadRawBytes(conn net.Conn, timeout time.Duration) ([]byte, error) {
 	if payloadLen == 0 {
 		return nil, fmt.Errorf("codec: zero-length payload")
 	}
-	if payloadLen > MaxFrameSize {
-		return nil, fmt.Errorf("codec: payload too large (%d > %d)", payloadLen, MaxFrameSize)
+	if payloadLen > maxFrameSize {
+		return nil, fmt.Errorf("codec: payload too large (%d > %d)", payloadLen, maxFrameSize)
 	}
 
 	payload := make([]byte, payloadLen)
@@ -186,6 +199,18 @@ func ReadRawBytes(conn net.Conn, timeout time.Duration) ([]byte, error) {
 		return nil, err
 	}
 	return payload, nil
+}
+
+// ReadRelayFrame reads one RustDesk BytesCodec frame in a mixed native
+// TCP/WebSocket relay session.
+func ReadRelayFrame(conn net.Conn) ([]byte, error) {
+	return readRawBytesLimit(conn, 0, RelayMaxFrameSize)
+}
+
+// WriteRelayFrame writes one RustDesk BytesCodec frame in a mixed native
+// TCP/WebSocket relay session.
+func WriteRelayFrame(conn net.Conn, payload []byte) error {
+	return writeRawBytesLimit(conn, payload, RelayMaxFrameSize)
 }
 
 // WriteFrame writes a framed protobuf message using RustDesk variable-length codec.

--- a/betterdesk-server/db/postgres.go
+++ b/betterdesk-server/db/postgres.go
@@ -1117,16 +1117,18 @@ func (pg *PostgresDB) GetIDChangeHistory(id string) ([]*IDChangeHistory, error) 
 	return history, rows.Err()
 }
 
-// IsRenamedPeerID returns true if the given ID was previously used and then
-// changed to a different one (appears as old_id in id_change_history).
+// IsRenamedPeerID returns true when id is a historical source ID that is no
+// longer a current peer. This permits legitimate round-trip renames (A → B →
+// A) while still reserving genuinely stale IDs.
 func (pg *PostgresDB) IsRenamedPeerID(id string) (bool, error) {
-	var count int
+	var renamed bool
 	err := pg.pool.QueryRow(pg.ctx,
-		`SELECT COUNT(*) FROM id_change_history WHERE old_id = $1`, id).Scan(&count)
+		`SELECT EXISTS(SELECT 1 FROM id_change_history WHERE old_id = $1)
+		    AND NOT EXISTS(SELECT 1 FROM peers WHERE id = $1)`, id).Scan(&renamed)
 	if err != nil {
 		return false, err
 	}
-	return count > 0, nil
+	return renamed, nil
 }
 
 // GetLatestRenameTarget returns the most recent new_id for old_id.

--- a/betterdesk-server/db/postgres_rename_test.go
+++ b/betterdesk-server/db/postgres_rename_test.go
@@ -1,0 +1,59 @@
+package db
+
+import (
+	"os"
+	"testing"
+)
+
+func TestPostgresRoundTripRenameTreatsCurrentIDAsActive(t *testing.T) {
+	dsn := os.Getenv("BETTERDESK_TEST_POSTGRES_DSN")
+	if dsn == "" {
+		t.Skip("BETTERDESK_TEST_POSTGRES_DSN is not set")
+	}
+
+	database, err := OpenPostgres(dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+	if err := database.Migrate(); err != nil {
+		t.Fatal(err)
+	}
+
+	const idA, idB = "PGROUND_A", "PGROUND_B"
+	cleanup := func() {
+		_, _ = database.pool.Exec(database.ctx,
+			`DELETE FROM id_change_history WHERE old_id = ANY($1) OR new_id = ANY($1)`,
+			[]string{idA, idB})
+		_, _ = database.pool.Exec(database.ctx,
+			`DELETE FROM peers WHERE id = ANY($1)`, []string{idA, idB})
+	}
+	cleanup()
+	t.Cleanup(cleanup)
+
+	if err := database.UpsertPeer(&Peer{ID: idA, Status: "ONLINE"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := database.ChangePeerID(idA, idB, "client"); err != nil {
+		t.Fatal(err)
+	}
+	if err := database.ChangePeerID(idB, idA, "client"); err != nil {
+		t.Fatal(err)
+	}
+
+	renamed, err := database.IsRenamedPeerID(idA)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if renamed {
+		t.Fatalf("current %s must not be treated as a stale renamed ID", idA)
+	}
+
+	renamed, err = database.IsRenamedPeerID(idB)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !renamed {
+		t.Fatalf("non-current %s should remain reserved as a renamed ID", idB)
+	}
+}

--- a/betterdesk-server/db/sqlite.go
+++ b/betterdesk-server/db/sqlite.go
@@ -1303,20 +1303,23 @@ func (s *SQLiteDB) GetIDChangeHistory(id string) ([]*IDChangeHistory, error) {
 	return history, rows.Err()
 }
 
-// IsRenamedPeerID returns true if the given ID was previously used and then
-// changed to a different one (appears as old_id in id_change_history).
-// This prevents a device from re-registering under its old ID after an
-// admin-initiated ID change (#97).
+// IsRenamedPeerID returns true when id is a historical source ID that is no
+// longer a current peer. An ID can legitimately become current again after a
+// round-trip rename (A → B → A); history alone must not redirect or reject A.
+// Current soft-deleted rows are also excluded here so the normal deletion
+// guard handles them instead of following stale rename history.
 func (s *SQLiteDB) IsRenamedPeerID(id string) (bool, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	var count int
-	err := s.db.QueryRow(`SELECT COUNT(*) FROM id_change_history WHERE old_id = ?`, id).Scan(&count)
+	var renamed bool
+	err := s.db.QueryRow(`
+		SELECT EXISTS(SELECT 1 FROM id_change_history WHERE old_id = ?)
+		   AND NOT EXISTS(SELECT 1 FROM peers WHERE id = ?)`, id, id).Scan(&renamed)
 	if err != nil {
 		return false, err
 	}
-	return count > 0, nil
+	return renamed, nil
 }
 
 // GetLatestRenameTarget returns the most recent new_id for old_id.

--- a/betterdesk-server/db/sqlite_test.go
+++ b/betterdesk-server/db/sqlite_test.go
@@ -629,6 +629,35 @@ func TestHardDeleteReleasesIDHistory(t *testing.T) {
 	}
 }
 
+func TestRoundTripRenameTreatsCurrentIDAsActive(t *testing.T) {
+	db := newTestDB(t)
+
+	if err := db.UpsertPeer(&Peer{ID: "ROUND_A", Status: "ONLINE"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.ChangePeerID("ROUND_A", "ROUND_B", "client"); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.ChangePeerID("ROUND_B", "ROUND_A", "client"); err != nil {
+		t.Fatal(err)
+	}
+
+	renamed, err := db.IsRenamedPeerID("ROUND_A")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if renamed {
+		t.Fatal("current ROUND_A must not be treated as a stale renamed ID")
+	}
+	renamed, err = db.IsRenamedPeerID("ROUND_B")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !renamed {
+		t.Fatal("non-current ROUND_B should remain reserved as a renamed ID")
+	}
+}
+
 func TestChangePeerIDCascadesDeviceTokens(t *testing.T) {
 	db := newTestDB(t)
 

--- a/betterdesk-server/peer/map.go
+++ b/betterdesk-server/peer/map.go
@@ -291,6 +291,60 @@ func (m *Map) Remove(id string) *Entry {
 	return e
 }
 
+// Rename moves a live peer to a new ID without closing its transport.
+//
+// ID changes are metadata updates, not disconnects. Using Remove followed by
+// Put here would close the peer's persistent TCP/WebSocket registration and
+// reinsert an entry that points at an already-closed connection. The renamed
+// device would then be able to initiate short-lived outbound requests, but it
+// could no longer receive inbound rendezvous messages.
+//
+// The second return value is false when oldID does not exist or newID is
+// already occupied. A no-op rename (oldID == newID) succeeds when the entry
+// exists.
+func (m *Map) Rename(oldID, newID string) (*Entry, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	e, ok := m.entries[oldID]
+	if !ok {
+		return nil, false
+	}
+	if oldID == newID {
+		return e, true
+	}
+	if _, exists := m.entries[newID]; exists {
+		return nil, false
+	}
+
+	delete(m.entries, oldID)
+	e.ID = newID
+	m.entries[newID] = e
+	return e, true
+}
+
+// TouchWSHeartbeat refreshes the peer currently bound to conn. Matching by
+// connection instead of a captured ID keeps heartbeats working when a live
+// WebSocket registration is renamed by another signal/API request.
+func (m *Map) TouchWSHeartbeat(conn interface{}) bool {
+	if conn == nil {
+		return false
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, e := range m.entries {
+		if e.WSConn != conn {
+			continue
+		}
+		e.LastReg = time.Now()
+		e.MissedBeats = 0
+		e.StatusTier = StatusOnline
+		e.HeartbeatCount++
+		return true
+	}
+	return false
+}
+
 // Count returns the number of peers currently in the map.
 func (m *Map) Count() int {
 	m.mu.RLock()

--- a/betterdesk-server/peer/map_test.go
+++ b/betterdesk-server/peer/map_test.go
@@ -6,6 +6,15 @@ import (
 	"time"
 )
 
+type testCloser struct {
+	closed bool
+}
+
+func (c *testCloser) Close() error {
+	c.closed = true
+	return nil
+}
+
 func TestMapPutGet(t *testing.T) {
 	m := NewMap()
 
@@ -43,6 +52,56 @@ func TestMapRemove(t *testing.T) {
 	}
 	if m.Get("R1") != nil {
 		t.Error("peer should be gone after remove")
+	}
+}
+
+func TestMapRenamePreservesLiveConnection(t *testing.T) {
+	m := NewMap()
+	conn := &testCloser{}
+	entry := &Entry{
+		ID:       "OLDID",
+		WSConn:   conn,
+		ConnType: ConnWS,
+		LastReg:  time.Now().Add(-time.Second),
+	}
+	m.Put(entry)
+
+	moved, ok := m.Rename("OLDID", "NEWID")
+	if !ok || moved != entry {
+		t.Fatalf("Rename = (%p, %v), want (%p, true)", moved, ok, entry)
+	}
+	if conn.closed {
+		t.Fatal("Rename closed the live WebSocket connection")
+	}
+	if m.Get("OLDID") != nil || m.Get("NEWID") != entry {
+		t.Fatal("renamed entry was not moved atomically")
+	}
+	if entry.WSConn != conn {
+		t.Fatal("Rename did not preserve the WebSocket binding")
+	}
+
+	previous := entry.LastReg
+	time.Sleep(time.Millisecond)
+	if !m.TouchWSHeartbeat(conn) {
+		t.Fatal("TouchWSHeartbeat did not find the renamed connection")
+	}
+	if !entry.LastReg.After(previous) {
+		t.Fatal("TouchWSHeartbeat did not refresh the renamed entry")
+	}
+}
+
+func TestMapRenameRejectsOccupiedTarget(t *testing.T) {
+	m := NewMap()
+	oldEntry := &Entry{ID: "OLDID", LastReg: time.Now()}
+	newEntry := &Entry{ID: "NEWID", LastReg: time.Now()}
+	m.Put(oldEntry)
+	m.Put(newEntry)
+
+	if moved, ok := m.Rename("OLDID", "NEWID"); ok || moved != nil {
+		t.Fatalf("Rename occupied target = (%v, %v), want (nil, false)", moved, ok)
+	}
+	if m.Get("OLDID") != oldEntry || m.Get("NEWID") != newEntry {
+		t.Fatal("failed Rename modified the map")
 	}
 }
 

--- a/betterdesk-server/relay/server.go
+++ b/betterdesk-server/relay/server.go
@@ -1,6 +1,8 @@
 // Package relay implements the BetterDesk relay server (hbbr equivalent).
-// It pairs two clients by UUID and creates a bidirectional byte stream between them.
-// The relay does NOT parse message.proto content — it's an opaque byte pipe.
+// It pairs two clients by UUID and relays their opaque message payloads.
+// Native TCP pairs use a raw byte pipe, WebSocket pairs preserve message
+// boundaries, and mixed pairs translate WebSocket messages to/from RustDesk
+// BytesCodec frames.
 package relay
 
 import (
@@ -25,15 +27,15 @@ import (
 
 // Server is the relay server instance.
 type Server struct {
-	cfg         *config.Config
-	bwLimiter   *ratelimit.BandwidthLimiter
-	connLimiter *ratelimit.ConnLimiter
+	cfg            *config.Config
+	bwLimiter      *ratelimit.BandwidthLimiter
+	connLimiter    *ratelimit.ConnLimiter
 	sessionLimiter *ratelimit.ConnLimiter // active paired sessions per IP (post-pair)
-	tcpLn       net.Listener
-	wsHTTP      *http.Server // WebSocket relay listener
-	ctx         context.Context
-	cancel      context.CancelFunc
-	wg          sync.WaitGroup
+	tcpLn          net.Listener
+	wsHTTP         *http.Server // WebSocket relay listener
+	ctx            context.Context
+	cancel         context.CancelFunc
+	wg             sync.WaitGroup
 
 	// Pending connections waiting for a pair (key: UUID string)
 	pending sync.Map // map[string]*pendingConn
@@ -53,8 +55,8 @@ var (
 )
 
 // relayTransport identifies how a peer reached the relay (framing differs).
-// TCP uses RustDesk BytesCodec; WebSocket uses one raw protobuf per binary frame.
-// Mixing them after UUID pairing corrupts the E2E handshake (#290).
+// TCP uses RustDesk BytesCodec while WebSocket uses one payload per binary
+// message. Mixed pairs therefore require a framing bridge.
 type relayTransport string
 
 const (
@@ -250,24 +252,25 @@ func (s *Server) handleConn(conn net.Conn) {
 // pairIncomingConn pairs two relay connections sharing the same session UUID.
 // LoadOrStore avoids a race where simultaneous connections both miss LoadAndDelete
 // and overwrite each other in pending without ever pairing.
-// Peers must use the same transport (TCP or WS); mixed framing is rejected (#290).
 func (s *Server) pairIncomingConn(pc *pendingConn, uuid string) {
 	if val, loaded := s.pending.LoadOrStore(uuid, pc); loaded {
 		existing := val.(*pendingConn)
-		s.pending.Delete(uuid)
-		close(existing.done)
-		if existing.transport != pc.transport {
-			log.Printf("[relay] Protocol mismatch for UUID %s: %s <-> %s (rejecting mixed WebSocket/native relay)",
-				uuid, existing.transport, pc.transport)
-			existing.close()
+		// A timeout or cleanup goroutine may concurrently remove the waiter.
+		// Only the goroutine that claims the exact entry may pair it.
+		if !s.pending.CompareAndDelete(uuid, existing) {
 			pc.close()
 			return
 		}
-		if pc.transport == relayTransportWS {
+		close(existing.done)
+		if existing.transport == relayTransportWS && pc.transport == relayTransportWS {
 			s.startWSRelay(existing.ws, pc.ws, existing.remoteAddr(), pc.remoteAddr(), uuid)
 			return
 		}
-		s.startRelay(existing.conn, pc.conn, uuid)
+		if existing.transport == relayTransportTCP && pc.transport == relayTransportTCP {
+			s.startRelay(existing.conn, pc.conn, uuid)
+			return
+		}
+		s.startMixedRelay(existing, pc, uuid)
 		return
 	}
 
@@ -275,14 +278,12 @@ func (s *Server) pairIncomingConn(pc *pendingConn, uuid string) {
 	case <-pc.done:
 		return
 	case <-timeAfter(config.RelayPairTimeout):
-		if val, ok := s.pending.Load(uuid); ok && val.(*pendingConn) == pc {
-			s.pending.Delete(uuid)
+		if s.pending.CompareAndDelete(uuid, pc) {
 			pc.close()
 			log.Printf("[relay] Pair timeout for UUID %s", uuid)
 		}
 	case <-s.ctx.Done():
-		if val, ok := s.pending.Load(uuid); ok && val.(*pendingConn) == pc {
-			s.pending.Delete(uuid)
+		if s.pending.CompareAndDelete(uuid, pc) {
 			pc.close()
 		}
 	}
@@ -414,6 +415,154 @@ func (c *idleTimeoutConn) Write(b []byte) (int, error) {
 	return n, err
 }
 
+// startMixedRelay translates complete WebSocket binary messages to and from
+// native RustDesk BytesCodec frames. Payload bytes remain opaque, preserving
+// the peer-to-peer E2E handshake and encrypted desktop/video messages.
+func (s *Server) startMixedRelay(first, second *pendingConn, uuid string) {
+	var wsPeer, tcpPeer *pendingConn
+	if first.transport == relayTransportWS {
+		wsPeer, tcpPeer = first, second
+	} else {
+		wsPeer, tcpPeer = second, first
+	}
+	if wsPeer.ws == nil || tcpPeer.conn == nil {
+		log.Printf("[relay] Invalid mixed relay endpoints for UUID %s", uuid)
+		first.close()
+		second.close()
+		return
+	}
+
+	if !s.acquireRelaySessions(first, second, uuid) {
+		return
+	}
+	defer s.releaseRelaySessions(first, second)
+
+	s.ActiveSessions.Add(1)
+	s.TotalRelayed.Add(1)
+	defer s.ActiveSessions.Add(-1)
+
+	log.Printf("[relay] Pair established: %s <-> %s (UUID: %s, transport=ws/tcp)",
+		first.remoteAddr(), second.remoteAddr(), uuid)
+	if s.onRelayStart != nil {
+		s.onRelayStart(uuid)
+	}
+	defer func() {
+		if s.onRelayEnd != nil {
+			s.onRelayEnd(uuid)
+		}
+		first.close()
+		second.close()
+		log.Printf("[relay] Session ended: UUID %s (active: %d)", uuid, s.ActiveSessions.Load()-1)
+	}()
+
+	var wsPace, tcpPace io.Writer
+	if s.bwLimiter != nil {
+		// Register two independently paced directions, matching native and
+		// WebSocket relay accounting.
+		_ = s.bwLimiter.WrapReader(strings.NewReader(""))
+		_ = s.bwLimiter.WrapReader(strings.NewReader(""))
+		wsPace = s.bwLimiter.WrapWriter(io.Discard)
+		tcpPace = s.bwLimiter.WrapWriter(io.Discard)
+		defer s.bwLimiter.SessionDone()
+		defer s.bwLimiter.SessionDone()
+	}
+
+	ctx := s.ctx
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	done := make(chan struct{})
+	var once sync.Once
+	finish := func() { once.Do(func() { close(done) }) }
+
+	// WebSocket -> TCP: one WS message becomes exactly one BytesCodec frame.
+	go func() {
+		defer finish()
+		for {
+			readCtx, cancel := context.WithTimeout(ctx, config.RelayIdleTimeout)
+			typ, payload, err := wsPeer.ws.Read(readCtx)
+			cancel()
+			if err != nil {
+				return
+			}
+			if typ != websocket.MessageBinary || len(payload) == 0 {
+				continue
+			}
+			if wsPace != nil {
+				_, _ = wsPace.Write(payload)
+			}
+			if err := tcpPeer.conn.SetWriteDeadline(time.Now().Add(config.RelayIdleTimeout)); err != nil {
+				return
+			}
+			if err := codec.WriteRelayFrame(tcpPeer.conn, payload); err != nil {
+				return
+			}
+		}
+	}()
+
+	// TCP -> WebSocket: one BytesCodec frame becomes exactly one WS message.
+	go func() {
+		defer finish()
+		for {
+			if err := tcpPeer.conn.SetReadDeadline(time.Now().Add(config.RelayIdleTimeout)); err != nil {
+				return
+			}
+			payload, err := codec.ReadRelayFrame(tcpPeer.conn)
+			if err != nil {
+				return
+			}
+			if tcpPace != nil {
+				_, _ = tcpPace.Write(payload)
+			}
+			writeCtx, cancel := context.WithTimeout(ctx, config.RelayIdleTimeout)
+			err = wsPeer.ws.Write(writeCtx, websocket.MessageBinary, payload)
+			cancel()
+			if err != nil {
+				return
+			}
+		}
+	}()
+
+	<-done
+}
+
+func (s *Server) acquireRelaySessions(first, second *pendingConn, uuid string) bool {
+	if s.sessionLimiter == nil {
+		return true
+	}
+	acquired := make([]string, 0, 2)
+	for _, endpoint := range []*pendingConn{first, second} {
+		ip, _, err := net.SplitHostPort(endpoint.remoteAddr())
+		if err != nil {
+			ip = endpoint.remoteAddr()
+		}
+		if !s.sessionLimiter.Acquire(ip) {
+			log.Printf("[relay] Active session limit exceeded for %s (UUID %s)", ip, uuid)
+			for _, acquiredIP := range acquired {
+				s.sessionLimiter.Release(acquiredIP)
+			}
+			first.close()
+			second.close()
+			return false
+		}
+		acquired = append(acquired, ip)
+	}
+	return true
+}
+
+func (s *Server) releaseRelaySessions(first, second *pendingConn) {
+	if s.sessionLimiter == nil {
+		return
+	}
+	for _, endpoint := range []*pendingConn{first, second} {
+		ip, _, err := net.SplitHostPort(endpoint.remoteAddr())
+		if err != nil {
+			ip = endpoint.remoteAddr()
+		}
+		s.sessionLimiter.Release(ip)
+	}
+}
+
 // cleanupPending periodically removes stale pending connections.
 func (s *Server) cleanupPending() {
 	defer s.wg.Done()
@@ -429,7 +578,7 @@ func (s *Server) cleanupPending() {
 			s.pending.Range(func(key, value any) bool {
 				pc := value.(*pendingConn)
 				if time.Since(pc.created) > config.RelayPairTimeout {
-					if _, loaded := s.pending.LoadAndDelete(key); loaded {
+					if s.pending.CompareAndDelete(key, pc) {
 						pc.close()
 						close(pc.done)
 					}

--- a/betterdesk-server/relay/ws_test.go
+++ b/betterdesk-server/relay/ws_test.go
@@ -198,7 +198,7 @@ func TestWSRelayLargeMessagePreserved(t *testing.T) {
 	}
 }
 
-func TestRelayRejectsMixedTCPAndWS(t *testing.T) {
+func TestMixedWSAndTCPRelayPreservesFraming(t *testing.T) {
 	cfg := config.DefaultConfig()
 	ln, err := net.Listen("tcp", ":0")
 	if err != nil {
@@ -219,7 +219,7 @@ func TestRelayRejectsMixedTCPAndWS(t *testing.T) {
 	uuid := "mixed-transport-uuid-290"
 	wsURL := fmt.Sprintf("ws://127.0.0.1:%d/", cfg.WSRelayPort())
 
-	// First peer: WebSocket RequestRelay
+	// First peer: WebSocket RequestRelay.
 	ws, _, err := websocket.Dial(ctx, wsURL, nil)
 	if err != nil {
 		t.Fatalf("WS dial: %v", err)
@@ -235,9 +235,7 @@ func TestRelayRejectsMixedTCPAndWS(t *testing.T) {
 	if err := ws.Write(ctx, websocket.MessageBinary, data); err != nil {
 		t.Fatalf("WS write: %v", err)
 	}
-	time.Sleep(50 * time.Millisecond)
-
-	// Second peer: native TCP RequestRelay with same UUID
+	// Second peer: native TCP RequestRelay with the same UUID.
 	conn, err := net.DialTimeout("tcp", fmt.Sprintf("127.0.0.1:%d", port), 5*time.Second)
 	if err != nil {
 		t.Fatalf("TCP dial: %v", err)
@@ -252,13 +250,51 @@ func TestRelayRejectsMixedTCPAndWS(t *testing.T) {
 	}
 
 	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		if srv.TotalRelayed.Load() > 0 {
-			t.Fatal("mixed TCP/WS pair must not start a relay session")
-		}
-		time.Sleep(20 * time.Millisecond)
+	for srv.TotalRelayed.Load() == 0 && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
 	}
-	if srv.ActiveSessions.Load() != 0 {
-		t.Fatalf("active sessions = %d, want 0", srv.ActiveSessions.Load())
+	if srv.TotalRelayed.Load() == 0 {
+		t.Fatal("mixed relay pair was not established")
+	}
+
+	// Native TCP -> WebSocket: remove the BytesCodec header and preserve one
+	// complete WebSocket binary message.
+	fromTCP := []byte("signed-id-over-framed-tcp")
+	if err := codec.WriteRelayFrame(conn, fromTCP); err != nil {
+		t.Fatalf("TCP framed write: %v", err)
+	}
+	readCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	typ, gotWS, err := ws.Read(readCtx)
+	if err != nil {
+		t.Fatalf("WS read after TCP frame: %v", err)
+	}
+	if typ != websocket.MessageBinary || string(gotWS) != string(fromTCP) {
+		t.Fatalf("TCP->WS mismatch: type=%v got=%q want=%q", typ, gotWS, fromTCP)
+	}
+
+	// WebSocket -> native TCP: add exactly one RustDesk BytesCodec header.
+	fromWS := []byte("public-key-over-websocket")
+	if err := ws.Write(ctx, websocket.MessageBinary, fromWS); err != nil {
+		t.Fatalf("WS data write: %v", err)
+	}
+	if err := conn.SetReadDeadline(time.Now().Add(5 * time.Second)); err != nil {
+		t.Fatalf("TCP deadline: %v", err)
+	}
+	gotTCP, err := codec.ReadRelayFrame(conn)
+	if err != nil {
+		t.Fatalf("TCP framed read after WS message: %v", err)
+	}
+	if string(gotTCP) != string(fromWS) {
+		t.Fatalf("WS->TCP mismatch: got=%q want=%q", gotTCP, fromWS)
+	}
+
+	// Ending the TCP side must produce a standards-compliant WS close frame.
+	conn.Close()
+	closeCtx, closeCancel := context.WithTimeout(ctx, 5*time.Second)
+	defer closeCancel()
+	_, _, err = ws.Read(closeCtx)
+	if status := websocket.CloseStatus(err); status != websocket.StatusNormalClosure {
+		t.Fatalf("WS close status=%v, err=%v; want normal closure", status, err)
 	}
 }

--- a/betterdesk-server/signal/handler.go
+++ b/betterdesk-server/signal/handler.go
@@ -583,15 +583,15 @@ func (s *Server) processIDChange(msg *pb.RegisterPk) *pb.RendezvousMessage {
 		return registerPkResponse(pb.RegisterPkResponse_SERVER_ERROR)
 	}
 
-	// Update in-memory map
-	oldEntry := s.peers.Remove(oldID)
-	if oldEntry != nil {
-		oldEntry.ID = newID
+	// Move the in-memory identity without closing its persistent registration.
+	// Remove+Put closes TCP/WSS and leaves the renamed device unable to receive
+	// inbound rendezvous requests until the client happens to reconnect.
+	oldEntry, moved := s.peers.Rename(oldID, newID)
+	if moved {
 		oldEntry.PK = effectivePK
 		if len(msg.Uuid) > 0 {
 			oldEntry.UUID = normalizePeerUUIDBytes(msg.Uuid)
 		}
-		s.peers.Put(oldEntry)
 	}
 
 	log.Printf("[signal] ID changed: %s → %s", oldID, newID)

--- a/betterdesk-server/signal/handler.go
+++ b/betterdesk-server/signal/handler.go
@@ -24,10 +24,6 @@ import (
 	pb "github.com/unitronix/betterdesk-server/proto"
 )
 
-// refuseRelayProtocolMismatch is returned when one peer uses WebSocket Mode
-// and the other uses native TCP/UDP — their relay framings are incompatible (#290).
-const refuseRelayProtocolMismatch = "Protocol mismatch: WebSocket and native TCP/UDP cannot share a relay session"
-
 // refuseInitiatorNotAuthorized is returned when PunchHole/RequestRelay comes from
 // a peer that is not registered (or not enrollment-approved in managed/locked).
 const refuseInitiatorNotAuthorized = "Not authorized"
@@ -35,14 +31,6 @@ const refuseInitiatorNotAuthorized = "Not authorized"
 // panelWebRemoteInitiatorID is the synthetic initiator id logged when PunchHole/
 // RequestRelay arrives from the Node panel WebSocket→TCP proxy (#302 Web Remote).
 const panelWebRemoteInitiatorID = "panel-web-remote"
-
-// relayTransportMismatch reports whether initiator and target use incompatible
-// relay transports (WebSocket Mode vs native TCP/UDP). Signaling may still be
-// mixed; this gate only covers the typical case where ConnType reflects the
-// client's relay mode. The relay server remains the hard barrier.
-func relayTransportMismatch(initiator, target peer.ConnType) bool {
-	return (initiator == peer.ConnWS) != (target == peer.ConnWS)
-}
 
 // handleUDPMessage dispatches a UDP message to the appropriate handler.
 func (s *Server) handleUDPMessage(msg *pb.RendezvousMessage, raddr *net.UDPAddr) {
@@ -1159,26 +1147,6 @@ func (s *Server) handleRequestRelay(msg *pb.RequestRelay, raddr *net.UDPAddr) {
 		return
 	}
 
-	// WebSocket Mode and native TCP/UDP cannot share a relay session (#290).
-	initiatorType := peer.ConnUDP
-	if initiator := s.peers.FindByIP(raddr.IP); initiator != nil {
-		initiatorType = initiator.ConnType
-	}
-	if relayTransportMismatch(initiatorType, target.ConnType) {
-		log.Printf("[signal] RequestRelay: protocol mismatch initiator=%s target=%s (%s vs %s)",
-			raddr, targetID, initiatorType, target.ConnType)
-		resp := &pb.RendezvousMessage{
-			Union: &pb.RendezvousMessage_RelayResponse{
-				RelayResponse: &pb.RelayResponse{
-					RefuseReason: refuseRelayProtocolMismatch,
-					RelayServer:  relayServer,
-				},
-			},
-		}
-		s.sendUDP(resp, raddr)
-		return
-	}
-
 	initiatorID := s.peerIDForAddr(raddr)
 	if s.billing != nil {
 		if check := s.billing.CheckConnection(targetID); !check.Allowed {
@@ -1274,9 +1242,10 @@ func (s *Server) handleRequestRelay(msg *pb.RequestRelay, raddr *net.UDPAddr) {
 // Previous behavior (sending nothing back and waiting for the target's
 // RelayResponse) caused timeouts for TCP signaling clients (e.g. logged-in users).
 //
-// initiatorHint is ConnTCP for native TCP signal or ConnWS for WebSocket Mode;
-// if the initiator is registered, their stored ConnType wins.
-func (s *Server) handleRequestRelayTCP(msg *pb.RequestRelay, raddr *net.UDPAddr, initiatorHint peer.ConnType) *pb.RendezvousMessage {
+// The transport hint remains part of this internal API because callers know
+// whether signaling arrived over TCP or WebSocket. Relay transport differences
+// are handled by the framing bridge and are not rejected here.
+func (s *Server) handleRequestRelayTCP(msg *pb.RequestRelay, raddr *net.UDPAddr, _ peer.ConnType) *pb.RendezvousMessage {
 	if raddr == nil {
 		log.Printf("[signal] RequestRelay (TCP): nil address, ignoring")
 		return nil
@@ -1322,24 +1291,6 @@ func (s *Server) handleRequestRelayTCP(msg *pb.RequestRelay, raddr *net.UDPAddr,
 			Union: &pb.RendezvousMessage_RelayResponse{
 				RelayResponse: &pb.RelayResponse{
 					RefuseReason: "Target offline",
-					RelayServer:  relayServer,
-				},
-			},
-		}
-	}
-
-	// WebSocket Mode and native TCP/UDP cannot share a relay session (#290).
-	initiatorType := initiatorHint
-	if initiator := s.peers.FindByIP(raddr.IP); initiator != nil {
-		initiatorType = initiator.ConnType
-	}
-	if relayTransportMismatch(initiatorType, target.ConnType) {
-		log.Printf("[signal] RequestRelay (TCP): protocol mismatch initiator=%s target=%s (%s vs %s)",
-			raddr, targetID, initiatorType, target.ConnType)
-		return &pb.RendezvousMessage{
-			Union: &pb.RendezvousMessage_RelayResponse{
-				RelayResponse: &pb.RelayResponse{
-					RefuseReason: refuseRelayProtocolMismatch,
 					RelayServer:  relayServer,
 				},
 			},

--- a/betterdesk-server/signal/handler_test.go
+++ b/betterdesk-server/signal/handler_test.go
@@ -660,7 +660,7 @@ func TestHandleRequestRelayTCPSamePublicIPIgnoresPrivateRelayHint(t *testing.T) 
 	}
 }
 
-func TestHandleRequestRelayTCPProtocolMismatch(t *testing.T) {
+func TestHandleRequestRelayTCPMixedTransportAllowed(t *testing.T) {
 	srv, _ := newTestSignalServer(t, config.EnrollmentModeOpen)
 	srv.localIP.Store("198.51.100.20")
 
@@ -681,15 +681,18 @@ func TestHandleRequestRelayTCPProtocolMismatch(t *testing.T) {
 
 	resp := srv.handleRequestRelayTCP(&pb.RequestRelay{
 		Id:   "NATIVETGT",
-		Uuid: "issue-290-mismatch-uuid",
+		Uuid: "issue-290-mixed-uuid",
 	}, udpAddr("198.51.100.30", 51000), peer.ConnWS)
 
 	rr := resp.GetRelayResponse()
 	if rr == nil {
 		t.Fatalf("expected RelayResponse, got %+v", resp)
 	}
-	if rr.RefuseReason != refuseRelayProtocolMismatch {
-		t.Fatalf("RefuseReason = %q, want %q", rr.RefuseReason, refuseRelayProtocolMismatch)
+	if rr.RefuseReason != "" {
+		t.Fatalf("unexpected RefuseReason %q", rr.RefuseReason)
+	}
+	if rr.Uuid != "issue-290-mixed-uuid" {
+		t.Fatalf("uuid = %q", rr.Uuid)
 	}
 }
 
@@ -726,27 +729,6 @@ func TestHandleRequestRelayTCPMatchingWSAllowed(t *testing.T) {
 	}
 	if rr.Uuid != "issue-290-match-uuid" {
 		t.Fatalf("uuid = %q", rr.Uuid)
-	}
-}
-
-func TestRelayTransportMismatchHelper(t *testing.T) {
-	cases := []struct {
-		a, b peer.ConnType
-		want bool
-	}{
-		{peer.ConnWS, peer.ConnTCP, true},
-		{peer.ConnWS, peer.ConnUDP, true},
-		{peer.ConnTCP, peer.ConnWS, true},
-		{peer.ConnUDP, peer.ConnWS, true},
-		{peer.ConnWS, peer.ConnWS, false},
-		{peer.ConnTCP, peer.ConnUDP, false},
-		{peer.ConnTCP, peer.ConnTCP, false},
-		{peer.ConnUDP, peer.ConnUDP, false},
-	}
-	for _, tc := range cases {
-		if got := relayTransportMismatch(tc.a, tc.b); got != tc.want {
-			t.Errorf("relayTransportMismatch(%s, %s) = %v, want %v", tc.a, tc.b, got, tc.want)
-		}
 	}
 }
 

--- a/betterdesk-server/signal/handler_test.go
+++ b/betterdesk-server/signal/handler_test.go
@@ -18,6 +18,15 @@ import (
 	"github.com/unitronix/betterdesk-server/ratelimit"
 )
 
+type signalTestCloser struct {
+	closed bool
+}
+
+func (c *signalTestCloser) Close() error {
+	c.closed = true
+	return nil
+}
+
 func newTestSignalServer(t *testing.T, mode string) (*Server, db.Database) {
 	t.Helper()
 
@@ -376,6 +385,41 @@ func TestProcessIDChangeSuccessEmptyPK(t *testing.T) {
 	}
 }
 
+func TestProcessIDChangePreservesLiveWSRegistration(t *testing.T) {
+	srv, database := newTestSignalServer(t, config.EnrollmentModeOpen)
+	storedPK := bytes.Repeat([]byte{0x42}, 32)
+	if err := database.UpsertPeer(&db.Peer{
+		ID: "LIVEOLD", PK: storedPK, Status: "ONLINE",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	conn := &signalTestCloser{}
+	entry := &peer.Entry{
+		ID:       "LIVEOLD",
+		PK:       storedPK,
+		ConnType: peer.ConnWS,
+		WSConn:   conn,
+		LastReg:  time.Now(),
+	}
+	srv.peers.Put(entry)
+
+	resp := srv.processIDChange(&pb.RegisterPk{
+		Id: "LIVENEW", OldId: "LIVEOLD", Uuid: []byte("machine-uid-bytes"),
+	})
+	if got := registerPkResult(resp); got != pb.RegisterPkResponse_OK {
+		t.Fatalf("ID change result = %v, want %v", got, pb.RegisterPkResponse_OK)
+	}
+	if conn.closed {
+		t.Fatal("ID change closed the persistent WS registration")
+	}
+	if srv.peers.Get("LIVEOLD") != nil || srv.peers.Get("LIVENEW") != entry {
+		t.Fatal("live peer map was not moved to the new ID")
+	}
+	if entry.WSConn != conn {
+		t.Fatal("renamed peer lost its WS connection binding")
+	}
+}
+
 func TestProcessIDChangeRejectsWrongPKWhenPKSent(t *testing.T) {
 	srv, database := newTestSignalServer(t, config.EnrollmentModeOpen)
 
@@ -418,6 +462,31 @@ func TestResolveRegistrationPeerIDRedirectsSameDevice(t *testing.T) {
 	effective, ok = srv.resolveRegistrationPeerID("MACPRO1", "198.51.100.99", nil, nil)
 	if ok {
 		t.Fatalf("resolveRegistrationPeerID different IP = (%q, %v), want reject", effective, ok)
+	}
+}
+
+func TestResolveRegistrationPeerIDAllowsCurrentRoundTripID(t *testing.T) {
+	srv, database := newTestSignalServer(t, config.EnrollmentModeOpen)
+	pk := bytes.Repeat([]byte{0x42}, 32)
+	if err := database.UpsertPeer(&db.Peer{
+		ID: "ROUND_A", Status: "ONLINE", PK: pk,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := database.ChangePeerID("ROUND_A", "ROUND_B", "client"); err != nil {
+		t.Fatal(err)
+	}
+	if err := database.ChangePeerID("ROUND_B", "ROUND_A", "client"); err != nil {
+		t.Fatal(err)
+	}
+
+	effective, ok := srv.resolveRegistrationPeerID("ROUND_A", "198.51.100.99", nil, nil)
+	if !ok || effective != "ROUND_A" {
+		t.Fatalf("current round-trip ID resolved as (%q, %v), want (ROUND_A, true)", effective, ok)
+	}
+	effective, ok = srv.resolveRegistrationPeerID("ROUND_B", "198.51.100.99", nil, pk)
+	if !ok || effective != "ROUND_A" {
+		t.Fatalf("stale round-trip ID resolved as (%q, %v), want (ROUND_A, true)", effective, ok)
 	}
 }
 

--- a/betterdesk-server/signal/ws.go
+++ b/betterdesk-server/signal/ws.go
@@ -209,9 +209,10 @@ func (s *Server) wsSignalLoop(wsc *codec.WSConn) {
 	remoteAddr := wsc.RemoteAddr()
 	peerID := ""
 	wsc.SetKeepAliveHandler(func() {
-		if peerID != "" {
-			s.peers.TouchHeartbeat(peerID)
-		}
+		// Follow the live connection rather than a captured ID. The ID may be
+		// changed by a separate API/TCP request while this WSS registration
+		// remains open.
+		s.peers.TouchWSHeartbeat(wsc)
 	})
 	keepAliveDone := make(chan struct{})
 	registered := make(chan struct{})
@@ -240,9 +241,10 @@ func (s *Server) wsSignalLoop(wsc *codec.WSConn) {
 
 		switch {
 		case msg.GetRegisterPeer() != nil:
-			peerID = msg.GetRegisterPeer().Id
-			resp := s.handleRegisterPeerWS(msg.GetRegisterPeer(), remoteAddr)
+			registerPeer := msg.GetRegisterPeer()
+			resp := s.handleRegisterPeerWS(registerPeer, remoteAddr)
 			if resp != nil {
+				peerID = registerPeer.Id
 				bindPeerWSConn(s, peerID, wsc)
 				s.registerWSPunchConn(remoteAddr, wsc)
 				notifyRegistered()
@@ -250,10 +252,11 @@ func (s *Server) wsSignalLoop(wsc *codec.WSConn) {
 			}
 
 		case msg.GetRegisterPk() != nil:
-			peerID = msg.GetRegisterPk().Id
-			resp := s.processRegisterPk(msg.GetRegisterPk(), remoteAddr)
+			registerPK := msg.GetRegisterPk()
+			resp := s.processRegisterPk(registerPK, remoteAddr)
 			if resp != nil {
 				if rpk := resp.GetRegisterPkResponse(); rpk != nil && rpk.GetResult() == pb.RegisterPkResponse_OK {
+					peerID = registerPK.Id
 					bindPeerWSConn(s, peerID, wsc)
 					s.registerWSPunchConn(remoteAddr, wsc)
 					notifyRegistered()
@@ -479,6 +482,7 @@ func (s *Server) handleRegisterPeerWS(msg *pb.RegisterPeer, remoteAddr string) *
 		return nil
 	} else if effectiveID != id {
 		id = effectiveID
+		msg.Id = effectiveID
 	}
 
 	existing := s.peers.Get(id)

--- a/betterdesk-server/signal/ws_test.go
+++ b/betterdesk-server/signal/ws_test.go
@@ -771,6 +771,88 @@ func TestWSSignalDesktopRegisterPkDelayed(t *testing.T) {
 	}
 }
 
+func TestWSSignalIDChangeKeepsInboundRegistrationOpen(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.SignalPort = 29400
+	cfg.RelayPort = 29401
+	dir := t.TempDir()
+	cfg.DBPath = dir + "/test.db"
+	cfg.KeyFile = dir + "/id_ed25519"
+
+	database, err := db.OpenSQLite(cfg.DBPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := database.Migrate(); err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+	kp, err := crypto.LoadOrGenerateKeyPair(cfg.KeyFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	srv := New(cfg, kp, database)
+	ctx := t.Context()
+	if err := srv.Start(ctx); err != nil {
+		t.Fatal(err)
+	}
+	defer srv.Stop()
+	time.Sleep(200 * time.Millisecond)
+
+	ws, _, err := websocket.Dial(ctx, "ws://127.0.0.1:29402/ws/id", nil)
+	if err != nil {
+		t.Fatalf("WS dial: %v", err)
+	}
+	defer ws.CloseNow()
+
+	writeProto := func(msg *pb.RendezvousMessage) {
+		t.Helper()
+		data, err := proto.Marshal(msg)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := ws.Write(ctx, websocket.MessageBinary, data); err != nil {
+			t.Fatalf("WS write: %v", err)
+		}
+	}
+
+	writeProto(&pb.RendezvousMessage{
+		Union: &pb.RendezvousMessage_RegisterPk{
+			RegisterPk: &pb.RegisterPk{
+				Id: "WSOLD01", Uuid: []byte("desktop-ws-uuid1"), Pk: make([]byte, 32),
+			},
+		},
+	})
+	if got := readWSProtoSkippingKeepAlive(t, ctx, ws).GetRegisterPkResponse().GetResult(); got != pb.RegisterPkResponse_OK {
+		t.Fatalf("initial RegisterPk result = %v, want OK", got)
+	}
+
+	// RustDesk 1.4.x omits pk in its ID-change RegisterPk request.
+	writeProto(&pb.RendezvousMessage{
+		Union: &pb.RendezvousMessage_RegisterPk{
+			RegisterPk: &pb.RegisterPk{
+				Id: "WSNEW01", OldId: "WSOLD01", Uuid: []byte("desktop-ws-uuid1"),
+			},
+		},
+	})
+	if got := readWSProtoSkippingKeepAlive(t, ctx, ws).GetRegisterPkResponse().GetResult(); got != pb.RegisterPkResponse_OK {
+		t.Fatalf("ID-change RegisterPk result = %v, want OK", got)
+	}
+
+	if srv.PeerMap().Get("WSOLD01") != nil || srv.PeerMap().Get("WSNEW01") == nil {
+		t.Fatal("renamed WSS peer was not moved to its new ID")
+	}
+	if err := srv.sendToWSPeer("WSNEW01", &pb.RendezvousMessage{
+		Union: &pb.RendezvousMessage_Hc{Hc: &pb.HealthCheck{Token: "inbound-after-id-change"}},
+	}); err != nil {
+		t.Fatalf("send inbound message after ID change: %v", err)
+	}
+	if got := readWSProtoSkippingKeepAlive(t, ctx, ws).GetHc(); got == nil || got.Token != "inbound-after-id-change" {
+		t.Fatalf("unexpected inbound message after ID change: %v", got)
+	}
+}
+
 func TestWSSignalXForwardedFor(t *testing.T) {
 	cfg := config.DefaultConfig()
 	cfg.SignalPort = 29170

--- a/web-nodejs/services/dbAdapter.js
+++ b/web-nodejs/services/dbAdapter.js
@@ -1138,10 +1138,31 @@ function createSqliteAdapter(config) {
     }
 
     /**
+     * True when id is a current Go signal-server identity. Rename history is
+     * append-only, so an ID may appear as old_id and later become current
+     * again after A -> B -> A.
+     */
+    function isCurrentPeerIdSqlite(id) {
+        const db = openMain();
+        try {
+            const hasGoPeers = db.prepare("SELECT 1 FROM sqlite_master WHERE type='table' AND name='peers'").get();
+            if (hasGoPeers) {
+                return !!db.prepare('SELECT 1 FROM peers WHERE id = ? LIMIT 1').get(id);
+            }
+        } catch (_) {}
+        try {
+            return !!db.prepare('SELECT 1 FROM peer WHERE id = ? LIMIT 1').get(id);
+        } catch (_) {
+            return false;
+        }
+    }
+
+    /**
      * Identity-aware rename guard — mirrors Go signal rejectRenamedPeerRegistration (#213).
      * @returns {{ reject: boolean, new_id?: string }}
      */
     function shouldRejectRenamedPeerRegistrationSqlite(oldId, { uuid, pk, ip } = {}) {
+        if (isCurrentPeerIdSqlite(oldId)) return { reject: false };
         const newId = (() => {
             try {
                 const db = openMain();
@@ -1387,6 +1408,7 @@ function createSqliteAdapter(config) {
         getRenamedPeerId(oldId) {
             try {
                 const db = openMain();
+                if (isCurrentPeerIdSqlite(oldId)) return null;
                 const tbl = db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='id_change_history'").get();
                 if (!tbl) return null;
                 const row = db.prepare('SELECT new_id FROM id_change_history WHERE old_id = ? ORDER BY rowid DESC LIMIT 1').get(oldId);
@@ -4494,11 +4516,24 @@ function createPostgresAdapter() {
         }
     }
 
+    async function isCurrentPeerIdPg(id) {
+        try {
+            return !!(await q1('SELECT 1 AS present FROM peers WHERE id = $1 LIMIT 1', [id]));
+        } catch (_) {
+            try {
+                return !!(await q1('SELECT 1 AS present FROM peer WHERE id = $1 LIMIT 1', [id]));
+            } catch (_) {
+                return false;
+            }
+        }
+    }
+
     /**
      * Identity-aware rename guard — mirrors Go signal rejectRenamedPeerRegistration (#213).
      * @returns {Promise<{ reject: boolean, new_id?: string }>}
      */
     async function shouldRejectRenamedPeerRegistrationPg(oldId, { uuid, pk, ip } = {}) {
+        if (await isCurrentPeerIdPg(oldId)) return { reject: false };
         let newId = null;
         try {
             const row = await q1('SELECT new_id FROM id_change_history WHERE old_id = $1 ORDER BY id DESC LIMIT 1', [oldId]);
@@ -4710,6 +4745,7 @@ function createPostgresAdapter() {
          */
         async getRenamedPeerId(oldId) {
             try {
+                if (await isCurrentPeerIdPg(oldId)) return null;
                 const row = await q1('SELECT new_id FROM id_change_history WHERE old_id = $1 ORDER BY id DESC LIMIT 1', [oldId]);
                 return row ? row.new_id : null;
             } catch (_) { return null; }

--- a/web-nodejs/tests/dbAdapter.renameRoundTrip.test.js
+++ b/web-nodejs/tests/dbAdapter.renameRoundTrip.test.js
@@ -1,0 +1,78 @@
+'use strict';
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const Database = require('better-sqlite3');
+
+jest.setTimeout(20000);
+
+describe('dbAdapter round-trip ID rename guard', () => {
+    let tmpDir;
+    let dataDir;
+    let dbPath;
+    let adapter;
+
+    beforeEach(async () => {
+        tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bd-rename-roundtrip-'));
+        dataDir = path.join(tmpDir, 'data');
+        fs.mkdirSync(dataDir);
+        dbPath = path.join(dataDir, 'db_v2.sqlite3');
+
+        process.env.DATA_DIR = dataDir;
+        process.env.DB_TYPE = 'sqlite';
+        process.env.DB_PATH = dbPath;
+        jest.resetModules();
+
+        const { getAdapter } = require('../services/dbAdapter');
+        adapter = getAdapter();
+        await adapter.init();
+
+        const db = new Database(dbPath);
+        db.exec(`
+            CREATE TABLE peers (
+                id TEXT PRIMARY KEY,
+                uuid TEXT DEFAULT '',
+                pk BLOB,
+                ip TEXT DEFAULT '',
+                soft_deleted INTEGER DEFAULT 0
+            );
+            CREATE TABLE id_change_history (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                old_id TEXT NOT NULL,
+                new_id TEXT NOT NULL
+            );
+            INSERT INTO id_change_history (old_id, new_id) VALUES
+                ('ROUND_A', 'ROUND_B'),
+                ('ROUND_B', 'ROUND_A');
+        `);
+        db.prepare('INSERT INTO peers (id, uuid, pk, ip) VALUES (?, ?, ?, ?)')
+            .run('ROUND_A', 'device-uuid', Buffer.alloc(32, 0x42), '203.0.113.50');
+        db.close();
+    });
+
+    afterEach(async () => {
+        if (adapter) await adapter.close();
+        delete process.env.DATA_DIR;
+        delete process.env.DB_TYPE;
+        delete process.env.DB_PATH;
+        if (tmpDir && fs.existsSync(tmpDir)) {
+            fs.rmSync(tmpDir, { recursive: true, force: true });
+        }
+    });
+
+    test('does not reject or redirect an ID that became current again', async () => {
+        expect(adapter.shouldRejectRenamedPeerRegistration('ROUND_A', {
+            uuid: 'unrelated-request-data',
+            ip: '198.51.100.25',
+        })).toEqual({ reject: false });
+        expect(adapter.getRenamedPeerId('ROUND_A')).toBeNull();
+    });
+
+    test('still redirects the stale intermediate ID to the current peer', async () => {
+        expect(adapter.shouldRejectRenamedPeerRegistration('ROUND_B', {
+            uuid: 'device-uuid',
+        })).toEqual({ reject: false, redirect_id: 'ROUND_A' });
+        expect(adapter.getRenamedPeerId('ROUND_B')).toBe('ROUND_A');
+    });
+});


### PR DESCRIPTION
> **Replacement for #266:** this PR keeps the same focused server fixes but uses a version-neutral source branch name and is rebased onto the current dev (3.5.13).

## Summary

This PR contains the two remaining server-side compatibility fixes that are not already present on the current `dev` (`3.5.13`):

- bridge mixed WebSocket/native TCP relay sessions instead of rejecting them;
- preserve a device's live registration when its ID is changed.

Related issues: #290, #213.

## Rebased additively on current dev

Current `dev` already contains the WSS first-response ordering fix, trusted-proxy/exact initiator hardening, graceful mixed-transport rejection and complete WebSocket-to-WebSocket large-message preservation from #276, #290 and #293. Those newer implementations remain in the base and are not duplicated here.

The previous PR history was rebuilt on top of that code. The mixed bridge extends the upstream relay transport model, and the ID-rename change preserves the current authorization, enrollment and database fixes.

## Changes

### Mixed WebSocket/native relay bridge

A WebSocket peer sends one opaque RustDesk payload per binary message. A native TCP/TLS peer uses RustDesk `BytesCodec` length framing whenever the other endpoint uses WebSocket. Forwarding both as one raw byte stream corrupts the E2E handshake; simply rejecting the pair prevents WebSocket ON/OFF interoperability.

The relay now supports every combination:

- native TCP ↔ native TCP: unchanged raw byte pipe;
- WebSocket ↔ WebSocket: unchanged complete-message forwarding from #293;
- WebSocket ↔ native TCP: complete WS messages are translated to/from bounded `BytesCodec` frames in both directions.

The implementation also:

- retains the upstream 16 MiB WebSocket message limit for relay/video payloads;
- uses atomic `CompareAndDelete` ownership so timeout cleanup cannot close a just-paired endpoint;
- preserves per-IP active-session and bandwidth accounting;
- sends a normal WebSocket close handshake when either mixed endpoint ends;
- removes the signal-layer protocol-mismatch refusal because the relay can now bridge it safely.

### Connected peer-ID rename

The old `Remove` + `Put` flow closed the device's persistent TCP/WSS registration. The renamed device remained able to initiate outbound requests but could not receive inbound rendezvous messages until reconnecting.

The peer map now renames an entry atomically without closing its transport. WSS heartbeats follow the live connection after a rename, registration handlers bind the effective ID, and round-trip renames (`A → B → A`) distinguish the current ID from rename history across:

- Go SQLite and PostgreSQL;
- Node.js SQLite and PostgreSQL adapters.

## Scope

This PR intentionally excludes unrelated console features:

- browser RdClient fixes are isolated in #282;
- widget and auditable Live-session reporting are isolated in #283;
- RustDesk Client Generator is isolated in #271.

## Validation

```bash
go test -count=1 ./codec ./relay ./signal ./peer ./db ./api
go vet ./codec ./relay ./signal ./peer ./db ./api
go test -race -count=1 ./relay ./signal ./peer

npm test -- --runInBand tests/dbAdapter.renameRoundTrip.test.js
```

Results:

- all listed Go package tests passed;
- race detector passed for relay, signal and peer;
- Go vet passed;
- Node ID-rename regression tests passed 2/2;
- mixed relay integration test verifies framed TCP → WS, WS → framed TCP and normal WS close.

## Security

- Relay allocations remain explicitly bounded.
- Current `dev` authorization, trusted-proxy and exact WSS initiator checks are preserved.
- Existing WebSocket origin validation remains enabled.
- No deployment domains, IP addresses, credentials, keys or private configuration are included.

## Commit structure

1. `fix(signal): preserve registrations across peer ID changes`
2. `fix(relay): bridge mixed WebSocket and native framing`

The already-upstream WSS response-ordering and relay-hardening commits were removed from this PR during the rebase instead of being duplicated.