### PR TITLE
fix(relay): support separate relay processes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 ### Changed
 - _(none yet)_
 
+### Fixed
+- **Standalone relay rejected every session after relay-ticket hardening:** add
+  explicit `RELAY_REQUIRE_TICKETS=N` compatibility for a relay running in a
+  different process or host from signal. Ticket enforcement remains enabled by
+  default for all-in-one deployments; disabling it emits a security warning and
+  restores official `hbbr`-compatible pairing by unguessable session UUID.
+
 ---
 
 ## [3.5.24] — 2026-08-07

--- a/README.md
+++ b/README.md
@@ -174,8 +174,11 @@ The Go server (`betterdesk-server/`) is a ~20,000 LOC clean-room implementation 
 # Signal only (no relay)
 ./betterdesk-server -mode signal
 
-# Relay only
+# Relay only on the same process/host as its signal authorization registry
 ./betterdesk-server -mode relay
+
+# Separate relay host (official hbbr-compatible UUID pairing)
+RELAY_REQUIRE_TICKETS=N ./betterdesk-server -mode relay
 ```
 
 ### Protocol Implementation
@@ -967,6 +970,7 @@ You can **upgrade to Let's Encrypt** or a custom certificate at any time using m
 | `-db` | `./db_v2.sqlite3` | `DB_URL` | Database DSN — file path (SQLite) or `postgres://...` (PostgreSQL) |
 | `-key-file` | `id_ed25519` | `KEY_FILE` | Ed25519 key file path (without extension) |
 | `-relay-servers` | *(empty)* | `RELAY_SERVERS` | Comma-separated relay addresses for `ConfigUpdate` |
+| *(none)* | `true` | `RELAY_REQUIRE_TICKETS` | Require process-local signal-issued relay UUID tickets. Set `N` only on a separate relay process; all-in-one keeps `Y`. |
 | `-rendezvous-servers` | *(empty)* | `RENDEZVOUS_SERVERS` | Comma-separated rendezvous addresses |
 | `-mask` | *(empty)* | `MASK` | LAN mask (e.g. `192.168.0.0/24`) |
 | `-always-relay` | `false` | `ALWAYS_USE_RELAY=Y` | Force relay for all connections (no P2P) |

--- a/betterdesk-server/config/config.go
+++ b/betterdesk-server/config/config.go
@@ -82,6 +82,7 @@ type Config struct {
 	// as panel-authorized initiators (#302 regression fix). Default: loopback.
 	PanelSignalProxyCIDRs []*net.IPNet
 	RelayMaxConnsIP       int    // Max relay connections per IP (0 = unlimited)
+	RelayRequireTickets   bool   // Require signal-issued UUID tickets (disable only on a separate relay process)
 	InitAdminUser         string // Initial admin username (created on first start)
 	InitAdminPass         string // Initial admin password (auto-generated if empty)
 
@@ -178,6 +179,7 @@ func DefaultConfig() *Config {
 		ClientSessionSliding:      true,
 		ClientSessionMaxDays:      30,
 		RelayMaxConnsIP:           20,
+		RelayRequireTickets:       true,
 		EnrollmentMode:            EnrollmentModeOpen, // Backward compatible default
 		PanelSignalProxyCIDRs:     panelCIDRs,
 		CDAPPort:                  21122,
@@ -342,6 +344,14 @@ func (c *Config) LoadEnv() {
 	if v := os.Getenv("RELAY_MAX_CONNS_PER_IP"); v != "" {
 		if n, err := strconv.Atoi(v); err == nil {
 			c.RelayMaxConnsIP = n
+		}
+	}
+	if v := strings.ToUpper(strings.TrimSpace(os.Getenv("RELAY_REQUIRE_TICKETS"))); v != "" {
+		switch v {
+		case "Y", "YES", "1", "TRUE", "ON":
+			c.RelayRequireTickets = true
+		case "N", "NO", "0", "FALSE", "OFF":
+			c.RelayRequireTickets = false
 		}
 	}
 	// Issue #122: allow tuning the per-IP signal/registration rate limit

--- a/betterdesk-server/config/config_test.go
+++ b/betterdesk-server/config/config_test.go
@@ -73,3 +73,20 @@ func TestLoadEnv_SignalPortPrecedenceOverPort(t *testing.T) {
 		t.Fatalf("SignalPort = %d, want 21116 (SIGNAL_PORT should win over PORT)", cfg.SignalPort)
 	}
 }
+
+func TestDefaultConfig_RelayTicketsAreRequired(t *testing.T) {
+	if !DefaultConfig().RelayRequireTickets {
+		t.Fatal("RelayRequireTickets must be enabled by default")
+	}
+}
+
+func TestLoadEnv_CanDisableRelayTicketsExplicitly(t *testing.T) {
+	t.Setenv("RELAY_REQUIRE_TICKETS", "N")
+
+	cfg := DefaultConfig()
+	cfg.LoadEnv()
+
+	if cfg.RelayRequireTickets {
+		t.Fatal("RelayRequireTickets = true, want false")
+	}
+}

--- a/betterdesk-server/relay/server.go
+++ b/betterdesk-server/relay/server.go
@@ -30,6 +30,7 @@ type Server struct {
 	connLimiter    *ratelimit.ConnLimiter
 	sessionLimiter *ratelimit.ConnLimiter // active paired sessions per IP (post-pair)
 	authorizations *AuthorizationRegistry
+	requireTickets bool
 	tcpLn          net.Listener
 	wsHTTP         *http.Server // WebSocket relay listener
 	ctx            context.Context
@@ -99,7 +100,15 @@ func New(cfg *config.Config) *Server {
 	return &Server{
 		cfg:            cfg,
 		authorizations: defaultAuthorizationRegistry,
+		requireTickets: cfg == nil || cfg.RelayRequireTickets,
 	}
+}
+
+func (s *Server) claimRelayTicket(uuid string) bool {
+	if !s.requireTickets {
+		return true
+	}
+	return s.authorizations != nil && s.authorizations.Claim(uuid)
 }
 
 // SetBandwidthLimiter sets the bandwidth limiter for relay sessions.
@@ -134,6 +143,9 @@ func (s *Server) SetBillingCallbacks(onStart, onEnd func(uuid string)) {
 // Start launches the relay TCP listener.
 func (s *Server) Start(ctx context.Context) error {
 	s.ctx, s.cancel = context.WithCancel(ctx)
+	if !s.requireTickets {
+		log.Printf("[relay] SECURITY WARNING: signal-issued relay UUID tickets are disabled (standalone compatibility mode)")
+	}
 
 	var err error
 	s.tcpLn, err = net.Listen("tcp", fmt.Sprintf(":%d", s.cfg.RelayPort))
@@ -248,7 +260,7 @@ func (s *Server) handleConn(conn net.Conn) {
 		conn.Close()
 		return
 	}
-	if s.authorizations == nil || !s.authorizations.Claim(uuid) {
+	if !s.claimRelayTicket(uuid) {
 		log.Printf("[relay] Unauthorized relay UUID from %s (rejecting)", conn.RemoteAddr())
 		conn.Close()
 		return

--- a/betterdesk-server/relay/server_test.go
+++ b/betterdesk-server/relay/server_test.go
@@ -30,6 +30,23 @@ func authorizeTestRelayPair(t *testing.T, uuid string) {
 	}
 }
 
+func TestStandaloneCompatibilityAcceptsUUIDWithoutLocalTicket(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.RelayRequireTickets = false
+	srv := New(cfg)
+
+	if !srv.claimRelayTicket("standalone-uuid") || !srv.claimRelayTicket("standalone-uuid") {
+		t.Fatal("standalone relay must accept both sides without a process-local signal ticket")
+	}
+}
+
+func TestRelayRejectsUUIDWithoutTicketByDefault(t *testing.T) {
+	srv := New(config.DefaultConfig())
+	if srv.claimRelayTicket("unknown-default-uuid") {
+		t.Fatal("all-in-one relay accepted a UUID without a signal-issued ticket")
+	}
+}
+
 func TestRelayPairing(t *testing.T) {
 	cfg := config.DefaultConfig()
 	cfg.RelayPort = 0 // let OS pick a free port

--- a/betterdesk-server/relay/server_test.go
+++ b/betterdesk-server/relay/server_test.go
@@ -40,6 +40,69 @@ func TestStandaloneCompatibilityAcceptsUUIDWithoutLocalTicket(t *testing.T) {
 	}
 }
 
+func TestStandaloneCompatibilityPairsWithoutLocalTicket(t *testing.T) {
+	ln, err := net.Listen("tcp", ":0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+	ln.Close()
+
+	cfg := config.DefaultConfig()
+	cfg.RelayPort = port
+	cfg.RelayRequireTickets = false
+	srv := New(cfg)
+	if err := srv.Start(t.Context()); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	defer srv.Stop()
+
+	addr := fmt.Sprintf("127.0.0.1:%d", port)
+	connA, err := net.DialTimeout("tcp", addr, 5*time.Second)
+	if err != nil {
+		t.Fatalf("dial A: %v", err)
+	}
+	defer connA.Close()
+	connB, err := net.DialTimeout("tcp", addr, 5*time.Second)
+	if err != nil {
+		t.Fatalf("dial B: %v", err)
+	}
+	defer connB.Close()
+
+	uuid := "standalone-wire-pair-uuid"
+	for _, side := range []struct {
+		conn net.Conn
+		id   string
+	}{{connA, "PEER_B"}, {connB, "PEER_A"}} {
+		if err := codec.WriteRawProto(side.conn, &pb.RendezvousMessage{
+			Union: &pb.RendezvousMessage_RequestRelay{
+				RequestRelay: &pb.RequestRelay{Uuid: uuid, Id: side.id},
+			},
+		}); err != nil {
+			t.Fatalf("write %s request: %v", side.id, err)
+		}
+	}
+
+	waitRelayPairing(t, srv)
+	payload := []byte("standalone relay payload")
+	if err := connA.SetWriteDeadline(time.Now().Add(5 * time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := connA.Write(payload); err != nil {
+		t.Fatalf("write payload: %v", err)
+	}
+	if err := connB.SetReadDeadline(time.Now().Add(5 * time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	got := make([]byte, len(payload))
+	if _, err := connB.Read(got); err != nil {
+		t.Fatalf("read payload: %v", err)
+	}
+	if string(got) != string(payload) {
+		t.Fatalf("payload mismatch: got %q, want %q", got, payload)
+	}
+}
+
 func TestRelayRejectsUUIDWithoutTicketByDefault(t *testing.T) {
 	srv := New(config.DefaultConfig())
 	if srv.claimRelayTicket("unknown-default-uuid") {

--- a/betterdesk-server/relay/ws.go
+++ b/betterdesk-server/relay/ws.go
@@ -137,7 +137,7 @@ func (s *Server) handleWSRelayUpgrade(w http.ResponseWriter, r *http.Request) {
 	}
 
 	uuid := rr.Uuid
-	if s.authorizations == nil || !s.authorizations.Claim(uuid) {
+	if !s.claimRelayTicket(uuid) {
 		log.Printf("[relay] WS unauthorized relay UUID from %s (rejecting)", r.RemoteAddr)
 		wsc.Close()
 		return


### PR DESCRIPTION
## Summary

Restore functional relay-only deployments after process-local UUID ticket enforcement was introduced. A relay on another process or host cannot see the signal server in-memory authorization registry, so strict ticket mode rejects every otherwise valid RustDesk relay session.

## Change

- Keep signal-issued relay UUID tickets required by default.
- Add explicit RELAY_REQUIRE_TICKETS=N for a separate relay process/host.
- Apply the setting consistently to native TCP and WebSocket relay connections.
- Emit a startup security warning whenever compatibility mode is enabled.
- Document the relay-only command and configuration trade-off.

## Security

All-in-one deployments remain fail-closed. Compatibility mode must be explicitly enabled and restores official hbbr-style pairing by the client-generated, unguessable session UUID. Empty UUIDs, rate limits, connection limits, frame bounds, TLS/WSS handling, and session timeouts remain enforced.

## Validation

- go test -count=1 ./config ./relay ./signal
- go vet ./config ./relay ./signal
- regression tests prove strict-by-default rejection and explicit standalone acceptance

No deployment domains, addresses, credentials, or private configuration are included.