### PR TITLE
fix(rustdesk): map panel Display name/Note to AB card alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ### Changed
 - _(none yet)_
 
+### Fixed
+- **Stock RustDesk — address book card shows ID instead of panel name:** peer cards use `alias` as the bold title (else formatted ID) and `username@hostname` (+ `note`) on the secondary line. BetterDesk maps panel **Display name** (else **Note**, else stale AB `note`) into RustDesk `alias`, hides the computer hostname when that managed label is set, and clears a duplicate `note`. Ships via panel update (console + Go rebuild/restart); re-login or refresh address book in RustDesk. Set Devices → Display name for the title you want.
+
 ---
 
 ## [3.5.27] — 2026-08-09

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - _(none yet)_
 
 ### Fixed
-- **Stock RustDesk — address book card shows ID instead of panel name:** peer cards use `alias` as the bold title (else formatted ID) and `username@hostname` (+ `note`) on the secondary line. BetterDesk maps panel **Display name** (else **Note**, else stale AB `note`) into RustDesk `alias`, hides the computer hostname when that managed label is set, and clears a duplicate `note`. Ships via panel update (console + Go rebuild/restart); re-login or refresh address book in RustDesk. Set Devices → Display name for the title you want.
+- **Stock RustDesk — address book card shows ID instead of panel name:** peer cards use `alias` as the bold title (else formatted ID) and `username@hostname` (+ `note`) on the secondary line. BetterDesk maps panel **Display name** (else **Note**, else stale AB `note`) into RustDesk `alias`, hides the computer hostname when that managed label is set, and clears a duplicate `note`. **Must land on `UNITRONIX/BetterDesk` `dev`** — panel Updates pull that repo by default (`UPDATE_GITHUB_OWNER`), not a personal fork; after update, rebuild/restart Go and re-login or refresh the address book in RustDesk. Set Devices → Display name for the title you want.
 
 ---
 

--- a/betterdesk-server/api/client_api_handlers.go
+++ b/betterdesk-server/api/client_api_handlers.go
@@ -694,23 +694,56 @@ func (s *Server) mergeAdminTagsIntoAB(data string) string {
 		}
 		filtered = append(filtered, p)
 
-		// Enrich peer with sysinfo from peers table (Issue #138: OS icon/name not showing)
+		// Enrich peer with sysinfo + panel display alias (Issue #138 + AB card title).
 		if info, ok := peerInfo[id]; ok {
-			if _, hasHostname := p["hostname"]; !hasHostname || p["hostname"] == "" {
-				if info.Hostname != "" {
-					p["hostname"] = info.Hostname
+			abAlias, _ := p["alias"].(string)
+			curHost, _ := p["hostname"].(string)
+			curUser, _ := p["username"].(string)
+			if strings.TrimSpace(curHost) == "" {
+				curHost = info.Hostname
+			}
+			if strings.TrimSpace(curUser) == "" {
+				curUser = info.User
+			}
+			alias, _, host, user := rustDeskCardFields(info, abAlias, curHost, curUser)
+			if a, _ := p["alias"].(string); strings.TrimSpace(a) != alias {
+				p["alias"] = alias
+				modified = true
+			}
+			// Avoid "Training" twice: clear AB note when it duplicates the title alias.
+			if note, _ := p["note"].(string); alias != "" && strings.TrimSpace(note) == alias {
+				p["note"] = ""
+				modified = true
+			}
+			// When a panel label drives the card title, clear computer name so it
+			// does not appear on the secondary line (and so group→AB merge does
+			// not refill hostname from /api/peers/list).
+			if alias != "" && rustDeskPanelAlias(info) != "" {
+				if h, _ := p["hostname"].(string); strings.TrimSpace(h) != "" {
+					p["hostname"] = ""
 					modified = true
+				}
+				if u, _ := p["username"].(string); strings.TrimSpace(u) != "" {
+					p["username"] = ""
+					modified = true
+				}
+			} else {
+				if _, hasHostname := p["hostname"]; !hasHostname || p["hostname"] == "" {
+					if host != "" {
+						p["hostname"] = host
+						modified = true
+					}
+				}
+				if _, hasUsername := p["username"]; !hasUsername || p["username"] == "" {
+					if user != "" {
+						p["username"] = user
+						modified = true
+					}
 				}
 			}
 			if _, hasPlatform := p["platform"]; !hasPlatform || p["platform"] == "" {
 				if info.OS != "" {
 					p["platform"] = info.OS
-					modified = true
-				}
-			}
-			if _, hasUsername := p["username"]; !hasUsername || p["username"] == "" {
-				if info.User != "" {
-					p["username"] = info.User
 					modified = true
 				}
 			}

--- a/betterdesk-server/api/client_api_handlers.go
+++ b/betterdesk-server/api/client_api_handlers.go
@@ -697,6 +697,7 @@ func (s *Server) mergeAdminTagsIntoAB(data string) string {
 		// Enrich peer with sysinfo + panel display alias (Issue #138 + AB card title).
 		if info, ok := peerInfo[id]; ok {
 			abAlias, _ := p["alias"].(string)
+			abNote, _ := p["note"].(string)
 			curHost, _ := p["hostname"].(string)
 			curUser, _ := p["username"].(string)
 			if strings.TrimSpace(curHost) == "" {
@@ -705,20 +706,22 @@ func (s *Server) mergeAdminTagsIntoAB(data string) string {
 			if strings.TrimSpace(curUser) == "" {
 				curUser = info.User
 			}
-			alias, _, host, user := rustDeskCardFields(info, abAlias, curHost, curUser)
+			alias, note, host, user := rustDeskCardFields(info, abAlias, abNote, curHost, curUser)
 			if a, _ := p["alias"].(string); strings.TrimSpace(a) != alias {
 				p["alias"] = alias
 				modified = true
 			}
-			// Avoid "Training" twice: clear AB note when it duplicates the title alias.
-			if note, _ := p["note"].(string); alias != "" && strings.TrimSpace(note) == alias {
-				p["note"] = ""
+			// Prefer enriched note (cleared when it duplicates the title alias).
+			if n, _ := p["note"].(string); strings.TrimSpace(n) != note {
+				p["note"] = note
 				modified = true
 			}
-			// When a panel label drives the card title, clear computer name so it
+			// When a managed label drives the card title, clear computer name so it
 			// does not appear on the secondary line (and so group→AB merge does
 			// not refill hostname from /api/peers/list).
-			if alias != "" && rustDeskPanelAlias(info) != "" {
+			managedTitle := rustDeskPanelAlias(info) != "" ||
+				(strings.TrimSpace(abAlias) == "" && alias != "" && strings.TrimSpace(abNote) != "" && alias == strings.TrimSpace(abNote))
+			if alias != "" && managedTitle {
 				if h, _ := p["hostname"].(string); strings.TrimSpace(h) != "" {
 					p["hostname"] = ""
 					modified = true

--- a/betterdesk-server/api/rustdesk_peer_display_test.go
+++ b/betterdesk-server/api/rustdesk_peer_display_test.go
@@ -16,7 +16,7 @@ func TestRustDeskCardFields_panelDisplayNameBecomesAlias(t *testing.T) {
 		DisplayName: "Training",
 		Note:        "Training",
 	}
-	alias, note, host, user := rustDeskCardFields(p, "", p.Hostname, p.User)
+	alias, note, host, user := rustDeskCardFields(p, "", "", p.Hostname, p.User)
 	if alias != "Training" {
 		t.Fatalf("alias=%q, want Training", alias)
 	}
@@ -32,7 +32,7 @@ func TestRustDeskCardFields_noteFillsAliasWhenNoDisplayName(t *testing.T) {
 	t.Parallel()
 
 	p := &db.Peer{ID: "1", Hostname: "pc-1", Note: "Front desk"}
-	alias, note, host, user := rustDeskCardFields(p, "", p.Hostname, "alice")
+	alias, note, host, user := rustDeskCardFields(p, "", "", p.Hostname, "alice")
 	if alias != "Front desk" {
 		t.Fatalf("alias=%q, want Front desk", alias)
 	}
@@ -48,7 +48,7 @@ func TestRustDeskCardFields_displayNameWinsOverAbAlias(t *testing.T) {
 	t.Parallel()
 
 	p := &db.Peer{DisplayName: "Training", Note: "other"}
-	alias, note, _, _ := rustDeskCardFields(p, "ClientRename", "host", "user")
+	alias, note, _, _ := rustDeskCardFields(p, "ClientRename", "", "host", "user")
 	if alias != "Training" {
 		t.Fatalf("panel display name should win, got %q", alias)
 	}
@@ -61,7 +61,7 @@ func TestRustDeskCardFields_keepsHostnameWithoutPanelLabel(t *testing.T) {
 	t.Parallel()
 
 	p := &db.Peer{ID: "1", Hostname: "pc-1"}
-	alias, note, host, user := rustDeskCardFields(p, "", "pc-1", "alice")
+	alias, note, host, user := rustDeskCardFields(p, "", "", "pc-1", "alice")
 	if alias != "" || note != "" {
 		t.Fatalf("expected empty alias/note, got alias=%q note=%q", alias, note)
 	}
@@ -74,13 +74,30 @@ func TestRustDeskCardFields_abAliasKeptWhenNoDisplayName(t *testing.T) {
 	t.Parallel()
 
 	p := &db.Peer{Hostname: "pc-1"}
-	alias, _, host, _ := rustDeskCardFields(p, "My Alias", "pc-1", "")
+	alias, _, host, _ := rustDeskCardFields(p, "My Alias", "", "pc-1", "")
 	if alias != "My Alias" {
 		t.Fatalf("alias=%q, want My Alias", alias)
 	}
 	// No panel label → do not strip hostname just because AB alias exists.
 	if host != "pc-1" {
 		t.Fatalf("host=%q, want pc-1", host)
+	}
+}
+
+func TestRustDeskCardFields_abNotePromotedWhenAliasEmpty(t *testing.T) {
+	t.Parallel()
+
+	// Matches Ole's screenshot: ID bold + hostname + note "Training", empty alias.
+	p := &db.Peer{ID: "1031876693", Hostname: "dcstrainingserver01"}
+	alias, note, host, user := rustDeskCardFields(p, "", "Training", p.Hostname, "admin")
+	if alias != "Training" {
+		t.Fatalf("alias=%q, want Training from AB note", alias)
+	}
+	if note != "" {
+		t.Fatalf("duplicate AB note should clear, got %q", note)
+	}
+	if host != "" || user != "" {
+		t.Fatalf("hostname should hide when AB note becomes title, got host=%q user=%q", host, user)
 	}
 }
 

--- a/betterdesk-server/api/rustdesk_peer_display_test.go
+++ b/betterdesk-server/api/rustdesk_peer_display_test.go
@@ -1,0 +1,98 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/unitronix/betterdesk-server/db"
+)
+
+func TestRustDeskCardFields_panelDisplayNameBecomesAlias(t *testing.T) {
+	t.Parallel()
+
+	p := &db.Peer{
+		ID:          "1031876693",
+		Hostname:    "dcstrainingserver01",
+		User:        "admin",
+		DisplayName: "Training",
+		Note:        "Training",
+	}
+	alias, note, host, user := rustDeskCardFields(p, "", p.Hostname, p.User)
+	if alias != "Training" {
+		t.Fatalf("alias=%q, want Training", alias)
+	}
+	if note != "" {
+		t.Fatalf("note should be cleared when it duplicates alias, got %q", note)
+	}
+	if host != "" || user != "" {
+		t.Fatalf("hostname/username should be hidden when panel alias is set, got host=%q user=%q", host, user)
+	}
+}
+
+func TestRustDeskCardFields_noteFillsAliasWhenNoDisplayName(t *testing.T) {
+	t.Parallel()
+
+	p := &db.Peer{ID: "1", Hostname: "pc-1", Note: "Front desk"}
+	alias, note, host, user := rustDeskCardFields(p, "", p.Hostname, "alice")
+	if alias != "Front desk" {
+		t.Fatalf("alias=%q, want Front desk", alias)
+	}
+	if note != "" {
+		t.Fatalf("duplicate note should clear, got %q", note)
+	}
+	if host != "" || user != "" {
+		t.Fatalf("expected cleared secondary line, got host=%q user=%q", host, user)
+	}
+}
+
+func TestRustDeskCardFields_displayNameWinsOverAbAlias(t *testing.T) {
+	t.Parallel()
+
+	p := &db.Peer{DisplayName: "Training", Note: "other"}
+	alias, note, _, _ := rustDeskCardFields(p, "ClientRename", "host", "user")
+	if alias != "Training" {
+		t.Fatalf("panel display name should win, got %q", alias)
+	}
+	if note != "other" {
+		t.Fatalf("distinct note should remain, got %q", note)
+	}
+}
+
+func TestRustDeskCardFields_keepsHostnameWithoutPanelLabel(t *testing.T) {
+	t.Parallel()
+
+	p := &db.Peer{ID: "1", Hostname: "pc-1"}
+	alias, note, host, user := rustDeskCardFields(p, "", "pc-1", "alice")
+	if alias != "" || note != "" {
+		t.Fatalf("expected empty alias/note, got alias=%q note=%q", alias, note)
+	}
+	if host != "pc-1" || user != "alice" {
+		t.Fatalf("expected hostname kept, got host=%q user=%q", host, user)
+	}
+}
+
+func TestRustDeskCardFields_abAliasKeptWhenNoDisplayName(t *testing.T) {
+	t.Parallel()
+
+	p := &db.Peer{Hostname: "pc-1"}
+	alias, _, host, _ := rustDeskCardFields(p, "My Alias", "pc-1", "")
+	if alias != "My Alias" {
+		t.Fatalf("alias=%q, want My Alias", alias)
+	}
+	// No panel label → do not strip hostname just because AB alias exists.
+	if host != "pc-1" {
+		t.Fatalf("host=%q, want pc-1", host)
+	}
+}
+
+func TestRustDeskPanelAlias(t *testing.T) {
+	t.Parallel()
+	if got := rustDeskPanelAlias(&db.Peer{DisplayName: " A ", Note: "B"}); got != "A" {
+		t.Fatalf("got %q", got)
+	}
+	if got := rustDeskPanelAlias(&db.Peer{Note: " B "}); got != "B" {
+		t.Fatalf("got %q", got)
+	}
+	if got := rustDeskPanelAlias(nil); got != "" {
+		t.Fatalf("got %q", got)
+	}
+}

--- a/betterdesk-server/api/rustdesk_peers.go
+++ b/betterdesk-server/api/rustdesk_peers.go
@@ -391,13 +391,18 @@ func rustDeskPanelAlias(p *db.Peer) string {
 // rustDeskCardFields maps BetterDesk peer metadata onto RustDesk card slots:
 //   - alias → bold primary title (else client shows formatted ID)
 //   - hostname/username → secondary line (username@hostname); cleared when a
-//     panel label is present so the computer name does not crowd the card
+//     managed label is present so the computer name does not crowd the card
 //   - note → trailing secondary text; cleared when it duplicates alias
+//
+// Title preference: panel display_name → panel note → existing AB alias → AB note.
+// A "managed" title (panel fields, or AB note promoted when alias was empty)
+// hides username@hostname. A client-typed AB alias alone does not.
 //
 // Stock RustDesk cannot put the ID on the secondary line — only alias vs ID
 // for the title, and username@hostname (+ note) below.
-func rustDeskCardFields(p *db.Peer, abAlias, deviceName, username string) (alias, note, outDevice, outUser string) {
+func rustDeskCardFields(p *db.Peer, abAlias, abNote, deviceName, username string) (alias, note, outDevice, outUser string) {
 	abAlias = strings.TrimSpace(abAlias)
+	abNote = strings.TrimSpace(abNote)
 	displayName := ""
 	peerNote := ""
 	if p != nil {
@@ -414,17 +419,28 @@ func rustDeskCardFields(p *db.Peer, abAlias, deviceName, username string) (alias
 		// Panel display name is the managed title for enrolled devices.
 		alias = displayName
 	} else if alias == "" {
-		alias = peerNote
+		if peerNote != "" {
+			alias = peerNote
+		} else if abNote != "" {
+			// Stale AB cards often keep the label in note with empty alias
+			// (pre-fix enrichment only filled hostname). Promote so the bold
+			// title is the label, not the formatted ID.
+			alias = abNote
+		}
 	}
 
 	note = peerNote
+	if note == "" {
+		note = abNote
+	}
 	if alias != "" && note == alias {
 		note = ""
 	}
 
 	outDevice, outUser = deviceName, username
-	if alias != "" && panelAlias != "" {
-		// Hide OS computer name when BetterDesk supplies a display label.
+	managedTitle := panelAlias != "" || (abAlias == "" && abNote != "" && alias == abNote)
+	if alias != "" && managedTitle {
+		// Hide OS computer name when BetterDesk / AB note supplies the title.
 		outDevice, outUser = "", ""
 	}
 	return alias, note, outDevice, outUser
@@ -467,15 +483,19 @@ func rustDeskPeerPayload(
 	deviceGroupName := rustDeskPeerDeviceGroupName(p.ID, assignments, folderNames, manualGroupNames)
 
 	abAlias := ""
+	abNote := ""
 	if abPeer != nil {
 		if ab, ok := abPeer[p.ID]; ok {
 			if a, ok := ab["alias"].(string); ok {
 				abAlias = a
 			}
+			if n, ok := ab["note"].(string); ok {
+				abNote = n
+			}
 		}
 	}
 
-	alias, note, deviceName, username := rustDeskCardFields(p, abAlias, deviceName, username)
+	alias, note, deviceName, username := rustDeskCardFields(p, abAlias, abNote, deviceName, username)
 	// When no panel/AB title is set, keep a non-empty device_name fallback for
 	// clients that still surface hostname in secondary UI chrome.
 	if alias == "" && deviceName == "" {

--- a/betterdesk-server/api/rustdesk_peers.go
+++ b/betterdesk-server/api/rustdesk_peers.go
@@ -376,6 +376,60 @@ func peerHasAllTagsLower(p *db.Peer, expected []string) bool {
 	return true
 }
 
+// rustDeskPanelAlias is the operator-facing label from the panel (display name,
+// then note). Stock RustDesk cards use peer.alias as the bold title when set.
+func rustDeskPanelAlias(p *db.Peer) string {
+	if p == nil {
+		return ""
+	}
+	if s := strings.TrimSpace(p.DisplayName); s != "" {
+		return s
+	}
+	return strings.TrimSpace(p.Note)
+}
+
+// rustDeskCardFields maps BetterDesk peer metadata onto RustDesk card slots:
+//   - alias → bold primary title (else client shows formatted ID)
+//   - hostname/username → secondary line (username@hostname); cleared when a
+//     panel label is present so the computer name does not crowd the card
+//   - note → trailing secondary text; cleared when it duplicates alias
+//
+// Stock RustDesk cannot put the ID on the secondary line — only alias vs ID
+// for the title, and username@hostname (+ note) below.
+func rustDeskCardFields(p *db.Peer, abAlias, deviceName, username string) (alias, note, outDevice, outUser string) {
+	abAlias = strings.TrimSpace(abAlias)
+	displayName := ""
+	peerNote := ""
+	if p != nil {
+		displayName = strings.TrimSpace(p.DisplayName)
+		peerNote = strings.TrimSpace(p.Note)
+	}
+	panelAlias := displayName
+	if panelAlias == "" {
+		panelAlias = peerNote
+	}
+
+	alias = abAlias
+	if displayName != "" {
+		// Panel display name is the managed title for enrolled devices.
+		alias = displayName
+	} else if alias == "" {
+		alias = peerNote
+	}
+
+	note = peerNote
+	if alias != "" && note == alias {
+		note = ""
+	}
+
+	outDevice, outUser = deviceName, username
+	if alias != "" && panelAlias != "" {
+		// Hide OS computer name when BetterDesk supplies a display label.
+		outDevice, outUser = "", ""
+	}
+	return alias, note, outDevice, outUser
+}
+
 func rustDeskPeerPayload(
 	s *Server,
 	p *db.Peer,
@@ -408,20 +462,24 @@ func rustDeskPeerPayload(
 			version = si.Version
 		}
 	}
-	if deviceName == "" {
-		deviceName = p.ID
-	}
 
 	tags := splitPeerTags(p.Tags)
 	deviceGroupName := rustDeskPeerDeviceGroupName(p.ID, assignments, folderNames, manualGroupNames)
 
-	alias := p.Note
+	abAlias := ""
 	if abPeer != nil {
 		if ab, ok := abPeer[p.ID]; ok {
-			if a, ok := ab["alias"].(string); ok && a != "" {
-				alias = a
+			if a, ok := ab["alias"].(string); ok {
+				abAlias = a
 			}
 		}
+	}
+
+	alias, note, deviceName, username := rustDeskCardFields(p, abAlias, deviceName, username)
+	// When no panel/AB title is set, keep a non-empty device_name fallback for
+	// clients that still surface hostname in secondary UI chrome.
+	if alias == "" && deviceName == "" {
+		deviceName = p.ID
 	}
 
 	online := s.peers.IsOnline(p.ID, config.RegTimeout)
@@ -431,7 +489,7 @@ func rustDeskPeerPayload(
 		"info":   map[string]any{"device_name": deviceName, "os": platform, "username": username, "version": version},
 		"status": statusInt,
 		"user":   username, "user_name": username,
-		"note":              p.Note,
+		"note":              note,
 		"device_group_name": deviceGroupName,
 		"tags":              tags,
 		"online":            online,

--- a/web-nodejs/routes/rustdesk-api.routes.js
+++ b/web-nodejs/routes/rustdesk-api.routes.js
@@ -628,23 +628,29 @@ async function getRustDeskPeerList(user, params = {}) {
         const hostname = sysinfo.hostname || device.hostname || '';
         const username = sysinfo.username || device.username || device.user || '';
         const platform = sysinfo.platform || device.platform || device.os || '';
-        const displayName = device.display_name || '';
-        const alias = displayName || device.note || hostname || String(device.id || '');
+        const displayName = String(device.display_name || '').trim();
+        const deviceNote = String(device.note || '').trim();
+        // Match Go rustDeskCardFields: panel display name / note → alias (bold title).
+        // Do not fall back to hostname (that belongs on the secondary line).
+        const alias = displayName || deviceNote;
+        const note = deviceNote && deviceNote !== alias ? deviceNote : '';
+        const infoHostname = alias ? '' : hostname;
+        const infoUsername = alias ? '' : username;
         const reachable = isReachableRustDeskDevice(device);
 
         // Match Go server PeerPayload format — info as nested map, status as int
         return {
             id: device.id,
             info: {
-                device_name: hostname,
+                device_name: infoHostname,
                 os: platform,
-                username: username,
+                username: infoUsername,
                 version: sysinfo.version || ''
             },
             status: 1,
-            user: username,
-            user_name: username,
-            note: device.note || '',
+            user: infoUsername,
+            user_name: infoUsername,
+            note,
             device_group_name: deviceGroupName,
             tags,
             online: reachable,

--- a/web-nodejs/services/rustdeskAddressBookSync.js
+++ b/web-nodejs/services/rustdeskAddressBookSync.js
@@ -91,10 +91,37 @@ function mergePeerFields(existing, device, tags) {
         : {};
 
     peer.id = String(peer.id || device.id || '');
-    if (!peer.username && (device.username || device.user)) peer.username = String(device.username || device.user);
-    if (!peer.hostname && device.hostname) peer.hostname = String(device.hostname);
-    if (!peer.alias && (device.display_name || device.note)) peer.alias = String(device.display_name || device.note);
-    if (!peer.platform && (device.platform || device.os)) peer.platform = String(device.platform || device.os);
+    const displayName = String(device.display_name || '').trim();
+    const deviceNote = String(device.note || '').trim();
+    const panelAlias = displayName || deviceNote;
+
+    // Panel display name is the managed RustDesk card title (alias). Note fills
+    // alias only when the peer has no alias yet. Never fall back to hostname —
+    // stock RustDesk already shows hostname on the secondary line.
+    if (displayName) {
+        peer.alias = displayName;
+    } else if (!peer.alias && deviceNote) {
+        peer.alias = deviceNote;
+    }
+
+    if (panelAlias) {
+        peer.hostname = '';
+        peer.username = '';
+        if (String(peer.note || '').trim() === panelAlias) {
+            peer.note = '';
+        }
+    } else {
+        if (!peer.username && (device.username || device.user)) {
+            peer.username = String(device.username || device.user);
+        }
+        if (!peer.hostname && device.hostname) {
+            peer.hostname = String(device.hostname);
+        }
+    }
+
+    if (!peer.platform && (device.platform || device.os)) {
+        peer.platform = String(device.platform || device.os);
+    }
     peer.tags = tags;
 
     return peer;

--- a/web-nodejs/services/rustdeskAddressBookSync.js
+++ b/web-nodejs/services/rustdeskAddressBookSync.js
@@ -96,18 +96,26 @@ function mergePeerFields(existing, device, tags) {
     const panelAlias = displayName || deviceNote;
 
     // Panel display name is the managed RustDesk card title (alias). Note fills
-    // alias only when the peer has no alias yet. Never fall back to hostname —
-    // stock RustDesk already shows hostname on the secondary line.
+    // alias only when the peer has no alias yet. Stale AB cards often keep the
+    // label in note with empty alias — promote that too. Never fall back to
+    // hostname (secondary line on stock RustDesk).
+    const existingAlias = String(peer.alias || '').trim();
+    const existingNote = String(peer.note || '').trim();
     if (displayName) {
         peer.alias = displayName;
-    } else if (!peer.alias && deviceNote) {
+    } else if (!existingAlias && deviceNote) {
         peer.alias = deviceNote;
+    } else if (!existingAlias && existingNote) {
+        peer.alias = existingNote;
     }
 
-    if (panelAlias) {
+    const titleAlias = String(peer.alias || '').trim();
+    const managedTitle = Boolean(panelAlias) ||
+        (!existingAlias && existingNote && titleAlias === existingNote);
+    if (managedTitle && titleAlias) {
         peer.hostname = '';
         peer.username = '';
-        if (String(peer.note || '').trim() === panelAlias) {
+        if (String(peer.note || '').trim() === titleAlias) {
             peer.note = '';
         }
     } else {

--- a/web-nodejs/tests/rustdesk-api.routes.test.js
+++ b/web-nodejs/tests/rustdesk-api.routes.test.js
@@ -163,15 +163,74 @@ describe('RustDesk Client API routes', () => {
             expect(res.body.data[0]).toMatchObject({
                 id: 'PEER1',
                 info: {
+                    device_name: '',
+                    os: 'Windows',
+                    username: ''
+                },
+                user: '',
+                user_name: '',
+                alias: 'Finance PC',
+                note: '',
+                online: true,
+                status: 1
+            });
+        });
+
+        it('uses device note as alias when display_name is empty', async () => {
+            authService.validateAccessToken.mockResolvedValue({ id: 3, username: 'operator1', role: 'operator' });
+            serverBackend.getAllDevices.mockResolvedValue([
+                {
+                    id: 'PEER2',
+                    hostname: 'dcstrainingserver',
+                    username: 'alice',
+                    platform: 'Windows',
+                    note: 'Training',
+                    online: true,
+                    tags: ['Allowed']
+                }
+            ]);
+
+            const res = await request(app)
+                .get('/api/peers')
+                .set('Authorization', 'Bearer operator-token');
+
+            expect(res.status).toBe(200);
+            expect(res.body.data[0]).toMatchObject({
+                id: 'PEER2',
+                alias: 'Training',
+                note: '',
+                info: { device_name: '', username: '', os: 'Windows' }
+            });
+        });
+
+        it('keeps hostname on secondary line when no panel display label exists', async () => {
+            authService.validateAccessToken.mockResolvedValue({ id: 3, username: 'operator1', role: 'operator' });
+            serverBackend.getAllDevices.mockResolvedValue([
+                {
+                    id: 'PEER3',
+                    hostname: 'server-a',
+                    username: 'alice',
+                    platform: 'Windows',
+                    online: true,
+                    tags: ['Allowed']
+                }
+            ]);
+
+            const res = await request(app)
+                .get('/api/peers')
+                .set('Authorization', 'Bearer operator-token');
+
+            expect(res.status).toBe(200);
+            expect(res.body.data[0]).toMatchObject({
+                id: 'PEER3',
+                alias: '',
+                info: {
                     device_name: 'server-a',
                     os: 'Windows',
                     username: 'alice'
                 },
                 user: 'alice',
-                user_name: 'alice',
-                alias: 'Finance PC',
-                online: true,
-                status: 1
+                user_name: 'alice'
             });
         });
 

--- a/web-nodejs/tests/rustdeskAddressBookSync.test.js
+++ b/web-nodejs/tests/rustdeskAddressBookSync.test.js
@@ -112,4 +112,63 @@ describe('rustdeskAddressBookSync', () => {
             JSON.stringify({ peers: [{ id: 'A' }], tags: [] })
         );
     });
+
+    it('maps panel display_name to alias and hides hostname on the card', () => {
+        const result = JSON.parse(sync.mergeAddressBookData(JSON.stringify({
+            peers: [{ id: '1031876693', hostname: 'dcstrainingserver', note: 'Training', tags: [] }],
+            tags: []
+        }), {
+            devices: [{
+                id: '1031876693',
+                hostname: 'dcstrainingserver',
+                display_name: 'Training',
+                note: 'Training',
+                tags: []
+            }],
+            includeDevices: false
+        }));
+
+        expect(result.peers[0]).toMatchObject({
+            id: '1031876693',
+            alias: 'Training',
+            hostname: '',
+            username: '',
+            note: ''
+        });
+    });
+
+    it('uses device note as alias when display_name is empty', () => {
+        const result = JSON.parse(sync.mergeAddressBookData(JSON.stringify({
+            peers: [{ id: '1', tags: [] }],
+            tags: []
+        }), {
+            devices: [{ id: '1', hostname: 'pc-1', note: 'Front desk', tags: [] }],
+            includeDevices: false
+        }));
+
+        expect(result.peers[0]).toMatchObject({
+            id: '1',
+            alias: 'Front desk',
+            hostname: ''
+        });
+        expect(result.peers[0].note || '').toBe('');
+    });
+
+    it('keeps hostname when the panel has no display label', () => {
+        const result = JSON.parse(sync.mergeAddressBookData(JSON.stringify({
+            peers: [{ id: '1', tags: [] }],
+            tags: []
+        }), {
+            devices: [{ id: '1', hostname: 'pc-1', username: 'alice', tags: [] }],
+            includeDevices: false
+        }));
+
+        expect(result.peers[0]).toMatchObject({
+            id: '1',
+            hostname: 'pc-1',
+            username: 'alice'
+        });
+        expect(result.peers[0].alias).toBeUndefined();
+    });
 });
+

--- a/web-nodejs/tests/rustdeskAddressBookSync.test.js
+++ b/web-nodejs/tests/rustdeskAddressBookSync.test.js
@@ -154,6 +154,30 @@ describe('rustdeskAddressBookSync', () => {
         expect(result.peers[0].note || '').toBe('');
     });
 
+    it('promotes stale AB note to alias when panel has no label', () => {
+        const result = JSON.parse(sync.mergeAddressBookData(JSON.stringify({
+            peers: [{
+                id: '1031876693',
+                hostname: 'dcstrainingserver',
+                username: 'admin',
+                note: 'Training',
+                tags: []
+            }],
+            tags: []
+        }), {
+            devices: [{ id: '1031876693', hostname: 'dcstrainingserver', tags: [] }],
+            includeDevices: false
+        }));
+
+        expect(result.peers[0]).toMatchObject({
+            id: '1031876693',
+            alias: 'Training',
+            hostname: '',
+            username: '',
+            note: ''
+        });
+    });
+
     it('keeps hostname when the panel has no display label', () => {
         const result = JSON.parse(sync.mergeAddressBookData(JSON.stringify({
             peers: [{ id: '1', tags: [] }],


### PR DESCRIPTION
﻿## Summary
- Stock RustDesk address book cards use peer alias as the bold title (else formatted ID) and username@hostname (+ note) below.
- Map panel Display name, else Note, else stale AB note into alias; hide computer hostname for that managed title; clear duplicate note text.
- Cherry-picked onto current UNITRONIX dev so panel Updates (default UPDATE_GITHUB_OWNER=UNITRONIX) can pull the fix. Pushing only to the Chesster1981 fork left production unchanged.

## Why the previous push did nothing
Panel updater defaults to UNITRONIX/BetterDesk. Commit 5b452d30 lived only on Chesster1981/BetterDesk dev and was not an ancestor of UNITRONIX dev.

## Test plan
- [ ] go test ./api/ -run RustDeskCard in betterdesk-server
- [ ] npx jest tests/rustdeskAddressBookSync.test.js tests/rustdesk-api.routes.test.js in web-nodejs
- [ ] After merge: Settings → Updates on Development channel → apply (console + Go rebuild/restart)
- [ ] Confirm GET /api/health version includes new Go commit suffix
- [ ] In RustDesk: re-login or refresh address book; peer with Display name/Note Training should show Training bold, not formatted ID + hostname
- [ ] Sample peer in GET /api/ab JSON: alias Training, hostname empty, note empty (or note only if distinct from alias)
