### PR TITLE
fix(cliprdr): restore local-to-remote Explorer file paste

### DIFF
--- a/.cursor/rules/chesster1981-fork-workflow.mdc
+++ b/.cursor/rules/chesster1981-fork-workflow.mdc
@@ -1,0 +1,34 @@
+---
+description: Day-to-day git remote is Chesster1981/BetterDesk; never PR/merge/push to UNITRONIX unless Ole explicitly asks
+alwaysApply: true
+---
+
+# Chesster1981 fork — default remote / branch
+
+## Default (always)
+
+| Item | Value |
+|------|--------|
+| Remote | **`origin`** → `https://github.com/Chesster1981/BetterDesk.git` |
+| Working branch | **`dev`** (operator’s fork) |
+| Push / PR target | **Chesster1981/BetterDesk** only |
+
+1. Before commit/push/PR: confirm `git remote -v` shows **Chesster1981**, and `git branch --show-current` is **`dev`** (or a feature branch off that fork’s `dev`).
+2. **Never** open PRs, merges, or push attempts against **UNITRONIX/BetterDesk** unless Ole **explicitly** asks in that session.
+3. Do **not** treat UNITRONIX issues/PRs (e.g. obsolete UNITRONIX #365) as merge targets for this workspace — Ole closes/ignores those himself.
+4. Day-to-day commits land on **`origin/dev`** (Chesster1981). Feature branches, if used, push to Chesster1981 and stay off UNITRONIX.
+
+## Panel Updates (Settings → Updates)
+
+Code already supports `UPDATE_GITHUB_OWNER` (default `UNITRONIX` in `updateService.js`). If this install should track the fork:
+
+- Panel update source / `UPDATE_GITHUB_OWNER` should be **`Chesster1981`** so Settings → Updates sees fork `dev` commits.
+- **Do not** invent or blindly change production `.env` — only mention or change when operator asks and existing merge/update paths support it (`envMerge` append-missing only).
+
+## Release exception (UNITRONIX)
+
+When Ole **explicitly** asks for an upstream / production release to UNITRONIX, follow [`betterdesk-release-workflow.mdc`](betterdesk-release-workflow.mdc). Default remains Chesster-only; severity or “critical” does **not** authorize UNITRONIX targeting.
+
+## Commit + push after panel-relevant rule/doc changes
+
+Follow [`panel-update-commit-push.mdc`](panel-update-commit-push.mdc): push target is **`origin/dev` on Chesster1981**, never UNITRONIX.

--- a/.cursor/rules/panel-update-commit-push.mdc
+++ b/.cursor/rules/panel-update-commit-push.mdc
@@ -1,0 +1,15 @@
+---
+description: After panel-update or agent-workflow rule changes, commit on dev and push to Chesster1981 origin/dev
+alwaysApply: true
+---
+
+# Panel update / agent-rule — commit and push
+
+When you change files that affect **Settings → Updates**, agent standing workflow, or deployable panel behaviour (including `.cursor/rules/` that encode that workflow):
+
+1. Work on **`dev`** (Chesster1981 fork).
+2. **Commit** when Ole asks, or when Ole’s standing instruction for that change type is commit+push (e.g. persisting workspace rules).
+3. **Push to `origin/dev`** on **Chesster1981/BetterDesk** — not UNITRONIX.
+4. Confirm with `git remote -v` and `git status -sb` that the tracking branch is `origin/dev` on the fork before `git push`.
+
+Do **not** open UNITRONIX PRs as part of this habit. Upstream release remains an explicit Ole request only (see `chesster1981-fork-workflow.mdc` + `betterdesk-release-workflow.mdc`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,21 +1,24 @@
-## [Unreleased]
-
-### Changed
-- _(none yet)_
-
----
-
-## [3.5.27] — 2026-08-09
-
-### Changed
-- _(none yet)_
-
----
-
-## [3.5.26] — 2026-08-09
+﻿## [Unreleased]
 
 ### Fixed
-- **Attestation Light theme contrast (#363):** Tier guide descriptions use `--text-primary`; IRON/TITANIUM/OBSIDIAN badge gradients stay readable on the dark chip; attestation cards use `--bg-secondary` (undefined `--bg-surface` removed). Ships via panel update (`server-attestation.css`). Verify: Light theme → Server Attestation → “What does each tier mean?” text and IRON/TITANIUM/OBSIDIAN badges are readable.
+- **RdClient desktop - local file Copy to remote Paste broken / ~1 min context-menu hang:** Panel updates pull from `UNITRONIX/BetterDesk`, which never received the fork Cliprdr recoveries. Three stacked regressions: (1) outbound FILEGROUPDESCRIPTOR omitted `FD_FILESIZE` so remote Explorer waited on `FILECONTENTS_SIZE` over the desktop relay (~1 minute "Not Responding"); (2) `remote.js` only pushed path-as-text on every mousedown and never called `syncCliprdrFiles`, wiping Cliprdr file formats after FormatList - Paste looked like a no-op; (3) sync Tauri clipboard IPC on the WebView UI thread deadlocked `OpenClipboard` after Explorer Copy. Restore `FD_FILESIZE` (sizes were always correct; the old 0 KB bug was base64 coerce + mistyped `FD_CREATETIME`/`0x08`), sync files before text and skip text when `CF_HDROP` is present, skip right-click sync, and run clipboard IPC via `async` + `spawn_blocking`. Requires panel update (`remote.js` / `cliprdr.js` / `clipboard.js`) **and** rebuilt `rdclient-desktop`.
+
+### Changed
+- _(none yet)_
+
+---
+
+## [3.5.27] â€” 2026-08-09
+
+### Changed
+- _(none yet)_
+
+---
+
+## [3.5.26] â€” 2026-08-09
+
+### Fixed
+- **Attestation Light theme contrast (#363):** Tier guide descriptions use `--text-primary`; IRON/TITANIUM/OBSIDIAN badge gradients stay readable on the dark chip; attestation cards use `--bg-secondary` (undefined `--bg-surface` removed). Ships via panel update (`server-attestation.css`). Verify: Light theme â†’ Server Attestation â†’ â€œWhat does each tier mean?â€ text and IRON/TITANIUM/OBSIDIAN badges are readable.
 - **Fleet org filter 404 (#364):** Fleet Management called non-existent `GET /api/panel/organizations`; it now uses `GET /api/panel/org` (same as Policies). Ships via panel update (`fleet.js`). Verify: Fleet page Network tab shows `/api/panel/org` (no 404), org dropdowns populate.
 
 ### Changed
@@ -23,35 +26,35 @@
 
 ---
 
-## [3.5.25] — 2026-08-08
+## [3.5.25] â€” 2026-08-08
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.5.24] — 2026-08-07
+## [3.5.24] â€” 2026-08-07
 
 ### Added
-- **RdClient desktop — native Cliprdr + folder file transfer stack (Refs #350):** recovered onto current `dev` from divergent history — Tauri `desktop_*` / `desktop_clipboard_*` IPC, `cliprdr.js`, desktop DnD, streamed folder upload/download. Requires rebuilt `rdclient-desktop` **and** panel update.
+- **RdClient desktop â€” native Cliprdr + folder file transfer stack (Refs #350):** recovered onto current `dev` from divergent history â€” Tauri `desktop_*` / `desktop_clipboard_*` IPC, `cliprdr.js`, desktop DnD, streamed folder upload/download. Requires rebuilt `rdclient-desktop` **and** panel update.
 
 ### Fixed
-- **Outbound “ID does not exist” after 3.5.16 (#302 residual):** stock RustDesk PunchHole/RequestRelay on a new TCP port (no login token, no shared RegisterPk session) was rejected as `initiator_not_registered` because 3.5.16 removed the safe `FindAllByIP` fallback restored in 3.5.15. Auth again authorizes when exactly one live peer shares the public IP; multiple live peers at that IP still refuse with `initiator_ambiguous_same_nat` (no identity inheritance). Ships via panel update (Go signal restart). Verify: stock client connect no longer shows “ID does not exist” when the initiator is the sole live peer at its public IP.
+- **Outbound â€œID does not existâ€ after 3.5.16 (#302 residual):** stock RustDesk PunchHole/RequestRelay on a new TCP port (no login token, no shared RegisterPk session) was rejected as `initiator_not_registered` because 3.5.16 removed the safe `FindAllByIP` fallback restored in 3.5.15. Auth again authorizes when exactly one live peer shares the public IP; multiple live peers at that IP still refuse with `initiator_ambiguous_same_nat` (no identity inheritance). Ships via panel update (Go signal restart). Verify: stock client connect no longer shows â€œID does not existâ€ when the initiator is the sole live peer at its public IP.
 - **Relay `Unauthorized relay UUID` after P2P fallback (#356):** when hole punch timed out and the target sent `RelayResponse`, signal forwarded the UUID without minting a relay ticket, so hbbr rejected both peers (`Reset by the peer(0)`). `handleRelayResponseForward` now authorizes the initiator/target pair before advertising the UUID (same ticket path as `RequestRelay`). Ships via panel update (Go signal/relay restart). Verify: connection that needs relay after P2P timeout succeeds; no `[relay] Unauthorized relay UUID` for that session.
-- **RdClient desktop — Copy-Paste / File Transfer creates 0KB empty remote files (#350):** Tauri IPC returns file chunks as base64 strings; JS treated them as `Uint8Array` constructors (`new Uint8Array(base64String)`), which always yields length 0, so Cliprdr and the File Transfer modal wrote empty remote files. `coerceBinaryPayload` now decodes base64 before upload/Cliprdr paths. Ships via panel update (`local-files.js` / `filetransfer.js` / `cliprdr.js` / `compress.js` / `protocol.js`).
-- **RdClient desktop — Cliprdr paste still 0KB after base64 coerce (#350):** outbound FILEGROUPDESCRIPTOR advertised `FD_FILESIZE` plus Windows `FD_CREATETIME` (0x08 mistyped as “unix mode”). Remote CliprdrStream trusted a bad/zero stream length and returned EOF without `FILECONTENTS_RANGE`. Descriptors now match RustDesk (`FD_ATTRIBUTES | FD_WRITESTIME | FD_PROGRESSUI`, size via `FILECONTENTS_SIZE` probe); FileContents rejects empty RANGE ACKs and serializes responses. Requires rebuilt `rdclient-desktop` **and** panel update (`cliprdr.js`). Verify: paste/upload a non-empty local file and confirm remote size matches.
-- **Enrollment QA follow-up (#351):** Enrollment Requests **All** filter aggregates pending + approved + rejected Go history. Reject & Ban → **Allow re-enroll** / Unban hard-deletes the enrollment audit peer so managed mode re-queues instead of leaving a zombie or bypassing approval. Orphan legacy `rejected_device_*` locks appear under Rejected. Devices `?search=` is applied on load (View device). Pending metadata can be enriched when HTTP enrollment supplies hostname/platform/version after a signal queue. Copy Device ID on the registrations table. Ships via panel update (Go API/signal restart).
+- **RdClient desktop â€” Copy-Paste / File Transfer creates 0KB empty remote files (#350):** Tauri IPC returns file chunks as base64 strings; JS treated them as `Uint8Array` constructors (`new Uint8Array(base64String)`), which always yields length 0, so Cliprdr and the File Transfer modal wrote empty remote files. `coerceBinaryPayload` now decodes base64 before upload/Cliprdr paths. Ships via panel update (`local-files.js` / `filetransfer.js` / `cliprdr.js` / `compress.js` / `protocol.js`).
+- **RdClient desktop â€” Cliprdr paste still 0KB after base64 coerce (#350):** outbound FILEGROUPDESCRIPTOR advertised `FD_FILESIZE` plus Windows `FD_CREATETIME` (0x08 mistyped as â€œunix modeâ€). Remote CliprdrStream trusted a bad/zero stream length and returned EOF without `FILECONTENTS_RANGE`. Descriptors now match RustDesk (`FD_ATTRIBUTES | FD_WRITESTIME | FD_PROGRESSUI`, size via `FILECONTENTS_SIZE` probe); FileContents rejects empty RANGE ACKs and serializes responses. Requires rebuilt `rdclient-desktop` **and** panel update (`cliprdr.js`). Verify: paste/upload a non-empty local file and confirm remote size matches.
+- **Enrollment QA follow-up (#351):** Enrollment Requests **All** filter aggregates pending + approved + rejected Go history. Reject & Ban â†’ **Allow re-enroll** / Unban hard-deletes the enrollment audit peer so managed mode re-queues instead of leaving a zombie or bypassing approval. Orphan legacy `rejected_device_*` locks appear under Rejected. Devices `?search=` is applied on load (View device). Pending metadata can be enriched when HTTP enrollment supplies hostname/platform/version after a signal queue. Copy Device ID on the registrations table. Ships via panel update (Go API/signal restart).
 
 ### Changed
 - **Devices drag & drop:** while dragging a device row onto folder/group chips, the panel content (`.main-content` / UX 3.5) auto-scrolls when the pointer nears the top or bottom edge.
 
 ---
 
-## [3.5.23] — 2026-08-05
+## [3.5.23] â€” 2026-08-05
 
 ### Fixed
 - **Support Agent rebuild profile gate:** Rebuild / Retry / post-update requeue now re-issues incomplete or expired signed Support Agent profiles (URLs + TTL) before enqueueing builds, so operators are not stuck in a Retry loop that only Save previously fixed.
-- **Support Agent version inject on flat deploys:** Build worker resolves product `VERSION` from the console install root (not `/opt` above a flattened tree) and treats an already-matching `var version` as success, fixing false “version variable not found” failures when the placeholder was still `0.1.0`.
+- **Support Agent version inject on flat deploys:** Build worker resolves product `VERSION` from the console install root (not `/opt` above a flattened tree) and treats an already-matching `var version` as success, fixing false â€œversion variable not foundâ€ failures when the placeholder was still `0.1.0`.
 - **Support Agent `build.sh` branding.pub backup:** Release packaging no longer requires a pre-existing `resources/branding.pub` before `sealbranding` creates it (fresh workspaces failed with `cp: cannot stat 'resources/branding.pub'`).
 - **Console CrashLoop after event-bus connect (#353):** Node.js abort `RemoveEnvironmentCleanupHook` / `(env) != nullptr` was a native N-API lifecycle failure (not Go event-bus init). Console now shares one `better-sqlite3` handle for the main DB (`getDb` / session store / enrollment token lookup), bumps `better-sqlite3` to 13.x for Node 24 Alpine, and defers agent build workers until after listen/WS connect. Ships via panel/Docker console image update.
 
@@ -60,205 +63,205 @@
 
 ---
 
-## [3.5.22] — 2026-08-05
+## [3.5.22] â€” 2026-08-05
 
 ### Changed
-- Support Agent generator and release profiles allow **HTTP/WS** (LAN/IP) as well as HTTPS/WSS; remote-session encryption remains on the signal/relay protocol layer (RustDesk-style). Uncheck “Use HTTPS / WSS” and re-save the bundle before rebuilding.
+- Support Agent generator and release profiles allow **HTTP/WS** (LAN/IP) as well as HTTPS/WSS; remote-session encryption remains on the signal/relay protocol layer (RustDesk-style). Uncheck â€œUse HTTPS / WSSâ€ and re-save the bundle before rebuilding.
 
 ---
 
-## [3.5.21] — 2026-08-05
-
-### Changed
-- _(none yet)_
-
----
-
-## [3.5.20] — 2026-08-05
+## [3.5.21] â€” 2026-08-05
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.5.19] — 2026-08-05
+## [3.5.20] â€” 2026-08-05
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.5.18] — 2026-08-05
+## [3.5.19] â€” 2026-08-05
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.5.17] — 2026-08-05
+## [3.5.18] â€” 2026-08-05
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.5.16] — 2026-08-05
+## [3.5.17] â€” 2026-08-05
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.5.15] — 2026-08-05
+## [3.5.16] â€” 2026-08-05
+
+### Changed
+- _(none yet)_
+
+---
+
+## [3.5.15] â€” 2026-08-05
 
 ### Security
-- **Dependabot dependency bumps:** `brace-expansion` → 5.0.9 (web-nodejs override), `postcss` → ≥8.5.23 (root + agent-client overrides), `quinn-proto` → 0.11.16 (RdClient Cargo.lock). Dev/build tooling and transitive deps only for postcss/quinn; brace-expansion via panel lockfile.
+- **Dependabot dependency bumps:** `brace-expansion` â†’ 5.0.9 (web-nodejs override), `postcss` â†’ â‰¥8.5.23 (root + agent-client overrides), `quinn-proto` â†’ 0.11.16 (RdClient Cargo.lock). Dev/build tooling and transitive deps only for postcss/quinn; brace-expansion via panel lockfile.
 - **CDAP file transfer dynamic callback (CodeQL):** validate `request_id` (string + whitelist) and use own-property lookup before invoking pending download callbacks in `cdap-filetransfer.js`. Ships via panel update (static JS).
 
 ### Fixed
-- **Outbound “ID does not exist” after 3.5.12 initiator hardening (#302 residual):** stock RustDesk PunchHole/RequestRelay on a new TCP port (no login token, no shared RegisterPk session) was rejected as `initiator_not_registered` because auth required exact `ip:port` only. Restore a safe IP fallback: authorize when exactly one live peer shares the public IP; multiple live peers at that IP still refuse with `initiator_ambiguous_same_nat` (no identity inheritance). Ships via panel update (Go signal restart).
+- **Outbound â€œID does not existâ€ after 3.5.12 initiator hardening (#302 residual):** stock RustDesk PunchHole/RequestRelay on a new TCP port (no login token, no shared RegisterPk session) was rejected as `initiator_not_registered` because auth required exact `ip:port` only. Restore a safe IP fallback: authorize when exactly one live peer shares the public IP; multiple live peers at that IP still refuse with `initiator_ambiguous_same_nat` (no identity inheritance). Ships via panel update (Go signal restart).
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.5.14] — 2026-08-04
+## [3.5.14] â€” 2026-08-04
 
 ### Fixed
-- **Enrollment history filters & irreversible reject (#351):** Go enrollment Approve/Reject now persists `enrollment_decision_*` history so Enrollment Requests **Approved** / **Rejected** filters show past decisions. Reject & Ban creates a `peers` row when missing so the device appears under Devices → Banned. New **Allow re-enroll** clears `rejected_device_*` (and enrollment bans); Unban also clears the rejection lock. Ships via panel update (Go API restart).
+- **Enrollment history filters & irreversible reject (#351):** Go enrollment Approve/Reject now persists `enrollment_decision_*` history so Enrollment Requests **Approved** / **Rejected** filters show past decisions. Reject & Ban creates a `peers` row when missing so the device appears under Devices â†’ Banned. New **Allow re-enroll** clears `rejected_device_*` (and enrollment bans); Unban also clears the rejection lock. Ships via panel update (Go API restart).
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.5.13] — 2026-08-03
+## [3.5.13] â€” 2026-08-03
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.5.12] — 2026-08-03
+## [3.5.12] â€” 2026-08-03
 
 ### Fixed
-- **Enrollment outbound same-NAT bypass (#302 residual):** PunchHole/RequestRelay initiator auth no longer uses IP-only `FindByIP` (a pending client behind the same public NAT as an approved peer could inherit that peer’s identity with no `Rejected outbound` log). Auth now requires exact `ip:port` (`FindByAddr`), the same TCP session after `RegisterPk`, a BetterDesk client login token, or `PANEL_SIGNAL_PROXY_CIDRS`. Ships via panel update (Go signal restart).
-- **Theme toggle blue flash (#320):** Light ↔ Dark preview briefly set solid hex into `--accent-*-muted` / `--ux35-active-bg`, so Enrollment filter pills, active sidebar item, and user avatar flashed bright blue until branding.css reloaded. Inline preview now uses the same `rgba(..., 0.15)` muted conversion as branding CSS. Ships via panel update.
+- **Enrollment outbound same-NAT bypass (#302 residual):** PunchHole/RequestRelay initiator auth no longer uses IP-only `FindByIP` (a pending client behind the same public NAT as an approved peer could inherit that peerâ€™s identity with no `Rejected outbound` log). Auth now requires exact `ip:port` (`FindByAddr`), the same TCP session after `RegisterPk`, a BetterDesk client login token, or `PANEL_SIGNAL_PROXY_CIDRS`. Ships via panel update (Go signal restart).
+- **Theme toggle blue flash (#320):** Light â†” Dark preview briefly set solid hex into `--accent-*-muted` / `--ux35-active-bg`, so Enrollment filter pills, active sidebar item, and user avatar flashed bright blue until branding.css reloaded. Inline preview now uses the same `rgba(..., 0.15)` muted conversion as branding CSS. Ships via panel update.
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.5.11] — 2026-08-03
+## [3.5.11] â€” 2026-08-03
 
 ### Added
 - **Support Agent completion (CDAP path):** Web Remote file transfer, in-session chat, remote audio, lock/restart control relay; Generator toolchain diagnostics + per-platform retry; immediate bundle rebuild after panel updates; last-good CDAP/API endpoint failover; branding seal + optional garble/UPX for release builds; capability flags in bundle branding. Ships via panel update (rebuild Support Agent bundles after update).
 
 ### Docs
 - **Support Agent** documented as the active end-user client: [`Desktop-Clients.md`](docs/wiki/Desktop-Clients.md), [`Client-Generator.md`](docs/wiki/Client-Generator.md), [`PROJECT_STRUCTURE.md`](docs/architecture/PROJECT_STRUCTURE.md).
-- **Docker panel HTTPS mismatch (#299):** documented Firefox `SSL_ERROR_RX_RECORD_TOO_LONG` / Chrome `ERR_SSL_PROTOCOL_ERROR` when opening `https://…:5000` against the default HTTP-only GHCR image — [`DOCKER_TROUBLESHOOTING.md`](docs/docker/DOCKER_TROUBLESHOOTING.md), [`DOCKER_QUICKSTART.md`](docs/docker/DOCKER_QUICKSTART.md).
+- **Docker panel HTTPS mismatch (#299):** documented Firefox `SSL_ERROR_RX_RECORD_TOO_LONG` / Chrome `ERR_SSL_PROTOCOL_ERROR` when opening `https://â€¦:5000` against the default HTTP-only GHCR image â€” [`DOCKER_TROUBLESHOOTING.md`](docs/docker/DOCKER_TROUBLESHOOTING.md), [`DOCKER_QUICKSTART.md`](docs/docker/DOCKER_QUICKSTART.md).
 
 ---
 
-## [3.5.10] — 2026-08-03
+## [3.5.10] â€” 2026-08-03
 
 ### Fixed
 - **Enrollment Requests filter contrast (#320):** active status filter buttons used undefined `--primary` with white text, so labels were unreadable in light theme. Active state now uses `--accent-blue` / `--accent-blue-muted` (same pattern as Devices/Tickets). Ships via panel update.
 
 ---
 
-## [3.5.9] — 2026-08-01
+## [3.5.9] â€” 2026-08-01
 
 ### Changed
-- **Help panel replaces guided tours:** the console Help control (UX 3.5, classic rail, Desktop Mode) opens a right-side panel with project supporters and GitHub / sponsorship links instead of spotlight tutorials. Tutorial JS/CSS, Settings → Tutorials, and the floating help FAB are removed. Supporters data lives in `web-nodejs/config/supporters.json` (keep in sync with `SPONSORS.md`). Ships via panel update.
+- **Help panel replaces guided tours:** the console Help control (UX 3.5, classic rail, Desktop Mode) opens a right-side panel with project supporters and GitHub / sponsorship links instead of spotlight tutorials. Tutorial JS/CSS, Settings â†’ Tutorials, and the floating help FAB are removed. Supporters data lives in `web-nodejs/config/supporters.json` (keep in sync with `SPONSORS.md`). Ships via panel update.
 
 ---
 
-## [3.5.8] — 2026-08-01
+## [3.5.8] â€” 2026-08-01
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.5.7] — 2026-08-01
+## [3.5.7] â€” 2026-08-01
 
 ### Fixed
-- **Native install TLS self-signed deploy regression (#325, discussion #322):** re-applied `_safe_cp_tls_file` no-op when source and dest are the same real file. The v3.4.3 fix was lost on the 3.5.0 merge; fresh `install.sh --native` again failed with `cp: cannot stat '.../betterdesk.crt'`. Symlink→copy for Let's Encrypt (#219) is unchanged. Ships via installer / `betterdesk.sh` (not panel-only). Verify: install completes past “Generating self-signed TLS certificates” with both `/opt/betterdesk/ssl/betterdesk.crt` and `.key` present.
+- **Native install TLS self-signed deploy regression (#325, discussion #322):** re-applied `_safe_cp_tls_file` no-op when source and dest are the same real file. The v3.4.3 fix was lost on the 3.5.0 merge; fresh `install.sh --native` again failed with `cp: cannot stat '.../betterdesk.crt'`. Symlinkâ†’copy for Let's Encrypt (#219) is unchanged. Ships via installer / `betterdesk.sh` (not panel-only). Verify: install completes past â€œGenerating self-signed TLS certificatesâ€ with both `/opt/betterdesk/ssl/betterdesk.crt` and `.key` present.
 - **UX 3.5 topbar turned blue / unreadable in light theme:** topbar chrome is now theme-invariant (always dark `#161b22` with light ink). Light/dark still flips sidebar and content. Ships via panel update.
 
 ### Changed
 - _(none yet)_
 
 ### Docs
-- **Peer password vs BetterDesk login (discussion #285):** clarified that Access Policy / device groups do not bypass the RustDesk peer password — [`Fleet-and-Policies.md`](docs/wiki/Fleet-and-Policies.md), [`SCOPED_REMOTE_USER.md`](docs/features/SCOPED_REMOTE_USER.md), [`RUSTDESK_CLIENT_DEPLOYMENT.md`](docs/setup/RUSTDESK_CLIENT_DEPLOYMENT.md).
+- **Peer password vs BetterDesk login (discussion #285):** clarified that Access Policy / device groups do not bypass the RustDesk peer password â€” [`Fleet-and-Policies.md`](docs/wiki/Fleet-and-Policies.md), [`SCOPED_REMOTE_USER.md`](docs/features/SCOPED_REMOTE_USER.md), [`RUSTDESK_CLIENT_DEPLOYMENT.md`](docs/setup/RUSTDESK_CLIENT_DEPLOYMENT.md).
 
 ---
 
-## [3.5.6] — 2026-08-01
+## [3.5.6] â€” 2026-08-01
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.5.5] — 2026-08-01
+## [3.5.5] â€” 2026-08-01
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.5.4] — 2026-08-01
+## [3.5.4] â€” 2026-08-01
 
 ### Fixed
 - **Address Book ACL bypass (restricted users) (#342):** `GET /api/ab` (and personal AB / tags) now filters peers and fleet tags through the same device-group / folder ACL as `/api/peers/list`, so org shared address-book merge and stale entries no longer expose out-of-scope machines. Unscoped `GET /api/peers` (without `accessible`/`pageSize`) applies the same ACL for non-admin roles. Ships via panel update (Go server + console).
 - **Legacy SQLite role CHECK blocking Phase 52 sync (#342):** upgraded `users` tables that still had `CHECK (role IN ('admin','operator','viewer'))` are rebuilt on Go `Migrate()` so `super_admin` / `global_admin` / `server_admin` / `pro` sync correctly. Installer/docs creators no longer add the old CHECK. Ships via panel update (Go server restart/migrate).
-- **MeshAgent `.msh` `bad size` (#336):** `GET /api/mesh/download.msh` no longer embeds the static 40-hex MeshID placeholder. Panel/API now emit a stable per-group 96-hex (SHA-384) `MeshID` (optional `mesh_id` query still accepted when 64/96 hex). Ships via panel update (Go restart). Verify: download `.msh` → `MeshID=` is `0x` + 96 hex chars; MeshAgent no longer exits with `bad size`.
+- **MeshAgent `.msh` `bad size` (#336):** `GET /api/mesh/download.msh` no longer embeds the static 40-hex MeshID placeholder. Panel/API now emit a stable per-group 96-hex (SHA-384) `MeshID` (optional `mesh_id` query still accepted when 64/96 hex). Ships via panel update (Go restart). Verify: download `.msh` â†’ `MeshID=` is `0x` + 96 hex chars; MeshAgent no longer exits with `bad size`.
 
 ---
 
-## [3.5.3] — 2026-08-01
+## [3.5.3] â€” 2026-08-01
 
 ### Fixed
-- **Dashboard Copy deploy string with invalid/placeholder public key (#340):** client config / deploy string / QR now require a valid Ed25519 key (base64 → 32 bytes), reject placeholders, and fall back to the live Go `GET /api/server-key` when `id_ed25519.pub` is missing or bad. Windows installer also sets `PUB_KEY_PATH` in the console NSSM environment. Ships via panel update (re-run `betterdesk.ps1` service setup to refresh NSSM env on Windows).
+- **Dashboard Copy deploy string with invalid/placeholder public key (#340):** client config / deploy string / QR now require a valid Ed25519 key (base64 â†’ 32 bytes), reject placeholders, and fall back to the live Go `GET /api/server-key` when `id_ed25519.pub` is missing or bad. Windows installer also sets `PUB_KEY_PATH` in the console NSSM environment. Ships via panel update (re-run `betterdesk.ps1` service setup to refresh NSSM env on Windows).
 
 ### Changed
-- **Runtime EOL refresh:** Docker/CI/installers use **Node.js 24 LTS** (`engines` ≥22); Go build images **golang:1.26-alpine**; server runtime **alpine:3.22**. Patch bumps for console (`axios`, `nodemailer`, `ws`, `pg`) and Go modules (incl. `modernc.org/sqlite`). SNMP bridge depends on **`pysnmp` ≥7.1** (replaces `pysnmplib`). See `docs/development/DEPENDENCY_UPGRADE_BACKLOG.md` for deferred Express 5 / native majors.
+- **Runtime EOL refresh:** Docker/CI/installers use **Node.js 24 LTS** (`engines` â‰¥22); Go build images **golang:1.26-alpine**; server runtime **alpine:3.22**. Patch bumps for console (`axios`, `nodemailer`, `ws`, `pg`) and Go modules (incl. `modernc.org/sqlite`). SNMP bridge depends on **`pysnmp` â‰¥7.1** (replaces `pysnmplib`). See `docs/development/DEPENDENCY_UPGRADE_BACKLOG.md` for deferred Express 5 / native majors.
 
 ### Docs
 - Refreshed `docs/architecture/PROJECT_STRUCTURE.md` for the current Go + Node layout; dependency upgrade backlog added.
 
 ---
 
-## [3.5.2] — 2026-07-31
+## [3.5.2] â€” 2026-07-31
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.5.1] — 2026-07-31
+## [3.5.1] â€” 2026-07-31
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.5.0] — 2026-07-31
+## [3.5.0] â€” 2026-07-31
 
 ### Added
 - **Optional UX 3.5 console shell (Beta):** full-list sidebar + topbar chrome available via navbar switch (BETA badge) or `?ui=ux35`. **Classic icon rail remains the default and supported production UI.** Docs: `docs/wiki/UX-3.5.md`. Ships via panel update.
-- **FreeBSD (Tier 3 / community):** example `rc.d` scripts and install notes under `contrib/freebsd/`. Refs #310. Manual build only — no CI FreeBSD binaries or panel updater support.
+- **FreeBSD (Tier 3 / community):** example `rc.d` scripts and install notes under `contrib/freebsd/`. Refs #310. Manual build only â€” no CI FreeBSD binaries or panel updater support.
 
 ### Changed
 - Dual-mode console chrome: operators who never switch stay on classic; UX 3.5 is explicitly labeled Beta while active (topbar chip). Escape hatch to classic unchanged.
-- Includes prior stable 3.4.1–3.4.3 hotfixes for operators updating from older stables in one step (#302 enrollment outbound hardening, #313 Web Remote panel-proxy, OIDC `user.info`, mesh cert hash, Unban kebab, and related fixes already on `main`).
+- Includes prior stable 3.4.1â€“3.4.3 hotfixes for operators updating from older stables in one step (#302 enrollment outbound hardening, #313 Web Remote panel-proxy, OIDC `user.info`, mesh cert hash, Unban kebab, and related fixes already on `main`).
 
 ### Fixed
-- **OIDC client login stuck on "Waiting…" (#304):** panel proxies `GET /api/auth/oidc/callback` (and `/api/oidc/callback`) to the Go API so Redirect URLs on the console origin complete RustDesk SSO. Ships via panel update.
+- **OIDC client login stuck on "Waitingâ€¦" (#304):** panel proxies `GET /api/auth/oidc/callback` (and `/api/oidc/callback`) to the Go API so Redirect URLs on the console origin complete RustDesk SSO. Ships via panel update.
 - **Docker AIO supervisord crash on missing NTP/billing env (#299):** entrypoint/Dockerfile default `NTP_SERVERS` and billing clock vars. Ships via image rebuild / `docker compose pull`.
 - **Rate limiter API path resolution:** more accurate path matching for console API rate limits. Ships via panel update.
 
@@ -268,7 +271,7 @@
 
 ---
 
-## [3.4.15] — 2026-07-31
+## [3.4.15] â€” 2026-07-31
 
 ### Changed
 - **UX 3.5 labeled Beta (opt-in):** classic console remains the default shell. The navbar switch to UX 3.5 shows a **BETA** badge/tooltip; while UX 3.5 is active a small BETA chip appears in the topbar. Escape hatch back to classic is unchanged. Ships via panel update.
@@ -278,7 +281,7 @@
 
 ---
 
-## [3.4.14] — 2026-07-31
+## [3.4.14] â€” 2026-07-31
 
 ### Changed
 - _(none yet)_
@@ -288,32 +291,32 @@
 
 ---
 
-## [3.4.3] — 2026-07-30
+## [3.4.3] â€” 2026-07-30
 
 
 ### Changed
 - **Client Configuration public key masked by default (#319):** Dashboard and Keys page show the KEY as bullets until revealed via an eye toggle; Copy still pastes the raw key. Ships via panel update.
-- **Docker update channel (#299):** Settings → Updates cannot switch stable/dev for GHCR image installs; use `BETTERDESK_IMAGE_TAG=latest` or `dev`, then `docker compose pull && up -d`. Panel shows a clear note; API returns `DOCKER_IMAGE_CHANNEL`.
+- **Docker update channel (#299):** Settings â†’ Updates cannot switch stable/dev for GHCR image installs; use `BETTERDESK_IMAGE_TAG=latest` or `dev`, then `docker compose pull && up -d`. Panel shows a clear note; API returns `DOCKER_IMAGE_CHANNEL`.
 
 ### Fixed
-- **OIDC client stuck on “Waiting account auth” (#326, #304):** `rustdeskUserPayload` now includes `user.info` (required by RustDesk 1.4.x serde). Callback could succeed while auth-query JSON was ignored. Ships via panel update (Go API restart).
-- **Viewer-only outbound “ID not found” with service stopped (#327):** TCP `RegisterPk` binds peer IP for `FindByIP`; punch/relay also accepts a valid BetterDesk client login token. Anonymous initiators stay blocked (#302). Ships via panel update (Go signal restart).
+- **OIDC client stuck on â€œWaiting account authâ€ (#326, #304):** `rustdeskUserPayload` now includes `user.info` (required by RustDesk 1.4.x serde). Callback could succeed while auth-query JSON was ignored. Ships via panel update (Go API restart).
+- **Viewer-only outbound â€œID not foundâ€ with service stopped (#327):** TCP `RegisterPk` binds peer IP for `FindByIP`; punch/relay also accepts a valid BetterDesk client login token. Anonymous initiators stay blocked (#302). Ships via panel update (Go signal restart).
 - **Enrollment outbound gate hardening (#302):** reject initiators that still have `pending_device_<id>` even if a peers row exists. Ships via panel update (Go signal restart).
-- **Web Remote SignedId MITM check + stale server key (#313):** viewer reads `id_ed25519.pub` on each page render (no empty cache if Go starts later); RdClient accepts base64 Key (and hex) and verifies `RelayResponse.pk` with the server key then `SignedId` with the peer identity key (RustDesk chain). Does not change the 3.4.2 panel-proxy allowlist. Ships via panel update. Note: desktop client `Failed to secure tcp: Signature mismatch in key exchange` when the Key field is empty/wrong is expected client config — set Key from Keys page / `id_ed25519.pub`.
-- **Cannot delete seed `admin` with false UI success (#315):** panel delete now checks Go Super Admin parity on dual-SQLite, mirrors delete before local removal, and returns 409/502 instead of success when Go refuses last-admin (no silent backfill restore). Last–Super Admin guard and installer `reset-password.js` / menu reset (username `admin`) are unchanged. Ships via panel update.
-- **Native install TLS self-signed deploy (#325):** `_safe_cp_tls_file` no longer deletes `betterdesk.crt` when source and dest are the same real file (self-signed generated in place). Symlink→copy for Let's Encrypt (#219) is unchanged. Ships via installer / `betterdesk.sh` (not panel-only). Verify: `install.sh --native` completes past “Generating self-signed TLS certificates” with both `/opt/betterdesk/ssl/betterdesk.crt` and `.key` present.
+- **Web Remote SignedId MITM check + stale server key (#313):** viewer reads `id_ed25519.pub` on each page render (no empty cache if Go starts later); RdClient accepts base64 Key (and hex) and verifies `RelayResponse.pk` with the server key then `SignedId` with the peer identity key (RustDesk chain). Does not change the 3.4.2 panel-proxy allowlist. Ships via panel update. Note: desktop client `Failed to secure tcp: Signature mismatch in key exchange` when the Key field is empty/wrong is expected client config â€” set Key from Keys page / `id_ed25519.pub`.
+- **Cannot delete seed `admin` with false UI success (#315):** panel delete now checks Go Super Admin parity on dual-SQLite, mirrors delete before local removal, and returns 409/502 instead of success when Go refuses last-admin (no silent backfill restore). Lastâ€“Super Admin guard and installer `reset-password.js` / menu reset (username `admin`) are unchanged. Ships via panel update.
+- **Native install TLS self-signed deploy (#325):** `_safe_cp_tls_file` no longer deletes `betterdesk.crt` when source and dest are the same real file (self-signed generated in place). Symlinkâ†’copy for Let's Encrypt (#219) is unchanged. Ships via installer / `betterdesk.sh` (not panel-only). Verify: `install.sh --native` completes past â€œGenerating self-signed TLS certificatesâ€ with both `/opt/betterdesk/ssl/betterdesk.crt` and `.key` present.
 - **Enrollment Requests UI (#320):** search icon no longer overlaps the placeholder; row dividers stay continuous under Platform/Actions (`display:flex` moved off `<td>`); Platform/Version/Status/Requested/Actions columns centered. Ships via panel update.
-- **MeshAgent `bad web cert hash` behind reverse proxy (#321):** PEM-aware `WebCertHash` (first `CERTIFICATE` SPKI SHA-384) and optional `MESH_WEB_CERT_FILE` for the public TLS cert agents see (e.g. NPM Let's Encrypt), independent of Go `TLS_CERT`. Ships via panel update (Go restart). Verify: mount LE fullchain → set `MESH_WEB_CERT_FILE` → agent registers without web-hash mismatch.
+- **MeshAgent `bad web cert hash` behind reverse proxy (#321):** PEM-aware `WebCertHash` (first `CERTIFICATE` SPKI SHA-384) and optional `MESH_WEB_CERT_FILE` for the public TLS cert agents see (e.g. NPM Let's Encrypt), independent of Go `TLS_CERT`. Ships via panel update (Go restart). Verify: mount LE fullchain â†’ set `MESH_WEB_CERT_FILE` â†’ agent registers without web-hash mismatch.
 - **Devices kebab Unban called Ban (#323):** kebab menu passed boolean `device.banned` while the handler only treated the string `'true'` as banned, so Unban opened the Ban modal and POSTed `/ban`. Both boolean and dataset string are accepted now. Ships via panel update.
-- **Client Configuration light theme contrast (#319):** replaced hardcoded dark `rgba(13,17,23,…)` panels with theme tokens (`--bg-tertiary` / `--bg-secondary`) so labels and endpoints stay readable in Light Theme. Ships via panel update.
+- **Client Configuration light theme contrast (#319):** replaced hardcoded dark `rgba(13,17,23,â€¦)` panels with theme tokens (`--bg-tertiary` / `--bg-secondary`) so labels and endpoints stay readable in Light Theme. Ships via panel update.
 
 ### Docs
-- **Caddy WebSocket Mode (#294):** client must use WSS (not `ws://` → HTTP 308); `TRUST_PROXY` / `TRUSTED_PROXIES` for correct peer IP after `/ws/id` upgrade. See `docs/setup/REVERSE_PROXY.md`.
+- **Caddy WebSocket Mode (#294):** client must use WSS (not `ws://` â†’ HTTP 308); `TRUST_PROXY` / `TRUSTED_PROXIES` for correct peer IP after `/ws/id` upgrade. See `docs/setup/REVERSE_PROXY.md`.
 - **Docker channel vs image tag (#299):** documented in `docs/docker/DOCKER_QUICKSTART.md`.
 
 ---
 
-## [3.4.13] — 2026-07-28
+## [3.4.13] â€” 2026-07-28
 
 ### Changed
 - _(none yet)_
@@ -323,7 +326,7 @@
 
 ---
 
-## [3.4.12] — 2026-07-26
+## [3.4.12] â€” 2026-07-26
 
 ### Changed
 - **UX 3.5 solid shell (performance):** glass/blur disabled in UX 3.5 chrome and content; opaque surfaces only. Classic shell glass branding unchanged. Ships via panel update.
@@ -334,24 +337,24 @@
 
 ---
 
-## [3.4.11] — 2026-07-26
+## [3.4.11] â€” 2026-07-26
 
 ### Changed
 - **UX 3.5 shell performance:** smoother sidebar resize (pointer capture + rAF, defer localStorage, disable glass blur while dragging), lighter page cards (no `backdrop-filter`), and cleaner tablet/phone drawer overlay fade. Ships via panel update.
 
 ---
 
-## [3.4.10] — 2026-07-26
+## [3.4.10] â€” 2026-07-26
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.4.9] — 2026-07-26
+## [3.4.9] â€” 2026-07-26
 
 ### Added
-- **FreeBSD (Tier 3 / community):** example `rc.d` scripts and install notes under `contrib/freebsd/`; documented in README platform table and wiki Installation. Refs #310. Manual build only — no CI FreeBSD binaries or panel updater support yet.
+- **FreeBSD (Tier 3 / community):** example `rc.d` scripts and install notes under `contrib/freebsd/`; documented in README platform table and wiki Installation. Refs #310. Manual build only â€” no CI FreeBSD binaries or panel updater support yet.
 
 ### Fixed
 - **Docker AIO supervisord crash on missing NTP/billing env (#299):** entrypoint and Dockerfile now default `NTP_SERVERS` and billing clock vars so Portainer / bare `docker run` / incomplete stacks no longer fail with `ENV_NTP_SERVERS` cannot be expanded. Also fixed corrupted `ENV ENCRYPTED_ONLY=1\nENV RELAY_SERVERS=` (was `ENCRYPTED_ONLY=1nENV` in the image).
@@ -359,14 +362,14 @@
 
 ---
 
-## [3.4.8] — 2026-07-26
+## [3.4.8] â€” 2026-07-26
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.4.7] — 2026-07-26
+## [3.4.7] â€” 2026-07-26
 
 ### Changed
 - **Console chrome dual mode:** default UI is again the classic icon rail + flyout. **UX 3.5** is available via a navbar/topbar switch (cookie `bd_ui_shell`, or `?ui=classic|ux35`). Docs: `docs/wiki/UX-3.5.md`. Ships via panel update.
@@ -377,48 +380,48 @@
 
 ---
 
-## [3.4.6] — 2026-07-26
+## [3.4.6] â€” 2026-07-26
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.4.5] — 2026-07-26
+## [3.4.5] â€” 2026-07-26
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.4.4] — 2026-07-26
+## [3.4.4] â€” 2026-07-26
 
 ### Added
-- **UX 3.5 default console shell:** native full-list sidebar + topbar (promoted from retired Beta 3.1), glass branding, Dark/Light/Custom themes in Settings → Branding, resizable sidebar, tablet/phone drawer. Login / RdClient / remote viewer unchanged. Docs: `docs/wiki/UX-3.5.md`. Ships via panel update.
+- **UX 3.5 default console shell:** native full-list sidebar + topbar (promoted from retired Beta 3.1), glass branding, Dark/Light/Custom themes in Settings â†’ Branding, resizable sidebar, tablet/phone drawer. Login / RdClient / remote viewer unchanged. Docs: `docs/wiki/UX-3.5.md`. Ships via panel update.
 
 ### Fixed
-- **UX 3.5 light theme only recolored the blue topbar:** `branding.css` kept emitting saved dark palette colors, and `ui-polish.css` was not loaded on the console layout — so body/sidebar text stayed light-on-dark. Light/Dark now resolve built-in palettes in `generateThemeCss()`, glass defaults follow the mode, and the topbar theme toggle persists the matching palette.
-- **UX 3.5 settings / main content invisible under branding wallpaper:** console wallpaper uses `body.app-page::before` at `z-index:0` while the old shell raised `.app-layout` to `z-index:1`. UX 3.5’s `.ux35-shell` had no stacking context, so the black wallpaper covered page text (sidebar/topbar still showed via their own z-index). `.ux35-shell` is now `position:relative; z-index:1` and branding background CSS includes `.ux35-shell` / `.ux35-content`.
+- **UX 3.5 light theme only recolored the blue topbar:** `branding.css` kept emitting saved dark palette colors, and `ui-polish.css` was not loaded on the console layout â€” so body/sidebar text stayed light-on-dark. Light/Dark now resolve built-in palettes in `generateThemeCss()`, glass defaults follow the mode, and the topbar theme toggle persists the matching palette.
+- **UX 3.5 settings / main content invisible under branding wallpaper:** console wallpaper uses `body.app-page::before` at `z-index:0` while the old shell raised `.app-layout` to `z-index:1`. UX 3.5â€™s `.ux35-shell` had no stacking context, so the black wallpaper covered page text (sidebar/topbar still showed via their own z-index). `.ux35-shell` is now `position:relative; z-index:1` and branding background CSS includes `.ux35-shell` / `.ux35-content`.
 
 ### Changed
 - **Console chrome:** TeamViewer-style rail/flyout and Desktop Mode are no longer loaded as the management UI; UX 3.5 is the single console interface on `dev`.
 
 ---
 
-## [3.4.3] — 2026-07-25
+## [3.4.3] â€” 2026-07-25
 
 ### Fixed
-- **OIDC client login stuck on “Waiting…” (#304):** panel now proxies `GET /api/auth/oidc/callback` (and `/api/oidc/callback`) to the Go API, so Redirect URLs that use the console origin (`:5000` / `:5443`) complete RustDesk SSO instead of returning 404. Settings also validate the callback path and clarify the hint. Ships via panel update. Verify: IdP Redirect URL = `https://<panel>/api/auth/oidc/callback` → SSO in RustDesk finishes with access token (browser shows success page).
+- **OIDC client login stuck on â€œWaitingâ€¦â€ (#304):** panel now proxies `GET /api/auth/oidc/callback` (and `/api/oidc/callback`) to the Go API, so Redirect URLs that use the console origin (`:5000` / `:5443`) complete RustDesk SSO instead of returning 404. Settings also validate the callback path and clarify the hint. Ships via panel update. Verify: IdP Redirect URL = `https://<panel>/api/auth/oidc/callback` â†’ SSO in RustDesk finishes with access token (browser shows success page).
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.4.2] — 2026-07-28
+## [3.4.2] â€” 2026-07-28
 
 ### Fixed
-- **Web Remote broken after enrollment outbound gate (#313, #302):** PunchHole/RequestRelay from the panel `/ws/rendezvous` proxy (default loopback CIDRs via `PANEL_SIGNAL_PROXY_CIDRS`) are accepted again without requiring a registered RustDesk peer. Unapproved clients and anonymous public initiators remain blocked. Ships via panel update (Go signal restart). Native/all-in-one needs no env change; Docker split console↔server must set `PANEL_SIGNAL_PROXY_CIDRS` to the console CIDR if still denied.
+- **Web Remote broken after enrollment outbound gate (#313, #302):** PunchHole/RequestRelay from the panel `/ws/rendezvous` proxy (default loopback CIDRs via `PANEL_SIGNAL_PROXY_CIDRS`) are accepted again without requiring a registered RustDesk peer. Unapproved clients and anonymous public initiators remain blocked. Ships via panel update (Go signal restart). Native/all-in-one needs no env change; Docker split consoleâ†”server must set `PANEL_SIGNAL_PROXY_CIDRS` to the console CIDR if still denied.
 - **npm audit (`brace-expansion`):** override bumped to `^5.0.8` (GHSA-mh99-v99m-4gvg) so Web Console CI `npm audit --omit=dev` passes on stable.
 
 ### Changed
@@ -426,26 +429,26 @@
 
 ---
 
-## [3.4.1] — 2026-07-25
+## [3.4.1] â€” 2026-07-25
 
 ### Fixed
-- **`betterdesk.sh` Online GitHub update leaves Console inactive (#306):** `start_services_with_verification` no longer aborts under `set -e` when `sqlite3` API-key sync fails after Go start; Console always gets `systemctl start`/`restart`, and update no longer prints success when `betterdesk-console` is not Active. Ships via installer script / next stable hotfix (not panel-only). Verify: Update → Online update from GitHub → `systemctl is-active betterdesk-console` is `active` without a manual start.
+- **`betterdesk.sh` Online GitHub update leaves Console inactive (#306):** `start_services_with_verification` no longer aborts under `set -e` when `sqlite3` API-key sync fails after Go start; Console always gets `systemctl start`/`restart`, and update no longer prints success when `betterdesk-console` is not Active. Ships via installer script / next stable hotfix (not panel-only). Verify: Update â†’ Online update from GitHub â†’ `systemctl is-active betterdesk-console` is `active` without a manual start.
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.4.0] — 2026-07-24
+## [3.4.0] â€” 2026-07-24
 
 ### Added
-- **OIDC login for stock RustDesk desktop clients (#304):** when panel OIDC is enabled, RustDesk Login shows an SSO option (`/api/login-options` + `/api/oidc/auth` / `auth-query`, same IdP config as panel SSO). Ships via panel update (Go API restart). Verify: enable OIDC → client SSO button → IdP login → access token.
-- **Guest Access Links for Web Remote / RdClient (#274):** time-limited opaque links with a device allowlist; guests open `/remote/guest?t=…` without a Console session. Mesh single-device share tunnel auth works with a valid `mesh_share` token.
+- **OIDC login for stock RustDesk desktop clients (#304):** when panel OIDC is enabled, RustDesk Login shows an SSO option (`/api/login-options` + `/api/oidc/auth` / `auth-query`, same IdP config as panel SSO). Ships via panel update (Go API restart). Verify: enable OIDC â†’ client SSO button â†’ IdP login â†’ access token.
+- **Guest Access Links for Web Remote / RdClient (#274):** time-limited opaque links with a device allowlist; guests open `/remote/guest?t=â€¦` without a Console session. Mesh single-device share tunnel auth works with a valid `mesh_share` token.
 - **RustDesk client LDAP/AD login (#218, #260):** desktop/mobile clients use the same directory auth as the web console. Operator guide: `docs/wiki/LDAP-AD.md`.
-- **RustDesk client sessions (#242):** DB-backed tokens (default 7 days, sliding renewal, max 30 days) under Settings → Authentication → RustDesk clients.
-- **MeshCentral compatibility layer:** optional `MESH_ENABLED=Y` — native Go `/agent.ashx` / `/meshrelay.ashx` / `/control.ashx`, inventory, guest share, port relay, recording. See `docs/features/MESHAGENT_ONBOARDING.md`.
+- **RustDesk client sessions (#242):** DB-backed tokens (default 7 days, sliding renewal, max 30 days) under Settings â†’ Authentication â†’ RustDesk clients.
+- **MeshCentral compatibility layer:** optional `MESH_ENABLED=Y` â€” native Go `/agent.ashx` / `/meshrelay.ashx` / `/control.ashx`, inventory, guest share, port relay, recording. See `docs/features/MESHAGENT_ONBOARDING.md`.
 - **BetterDesk Agent Client (alpha):** new Tauri enrollment / remote-agent client tree (`betterdesk-agent-client/`).
-- **Update channel:** Stable (`main`) vs Development (`dev`) in Settings → Updates (and installer scripts).
+- **Update channel:** Stable (`main`) vs Development (`dev`) in Settings â†’ Updates (and installer scripts).
 
 ### Fixed
 - **WebSocket Mode behind Nginx / reverse proxy (#276):** signal WSS no longer builds session keys as `IP:0` from proxied headers; PunchHole/RelayResponse reaches WebSocket initiators. **Manual:** set `TRUST_PROXY=Y` and `TRUSTED_PROXIES=<proxy CIDR>`, restart Go, use IP-only `X-Real-IP`, confirm logs show `effective=<client-ip>:<non-zero-port>`.
@@ -463,14 +466,14 @@
 - **HttpProxyRequest (#296):** schema support with `error: "not supported"` (no open HTTP egress proxy).
 - **Guest WebSocket proxy:** `/ws/rendezvous` and `/ws/relay` validate guest tokens via Go `/guest/access-links/validate` before upgrade (non-empty `?guest=` alone is no longer sufficient).
 - **RustDesk OIDC auth-query:** when the pending login recorded a device `id`/`uuid`, poll requests must supply matching non-empty values (omission no longer skips binding).
-- Dependency / CI hardening: npm audit overrides (`tar` ≥7.5.21), govulncheck, Go toolchain bump, WebSocket auth for bd-signal / remote-agent.
+- Dependency / CI hardening: npm audit overrides (`tar` â‰¥7.5.21), govulncheck, Go toolchain bump, WebSocket auth for bd-signal / remote-agent.
 
 ### Changed
-- Stable channel jump from **3.3.39** (previous `main`) through development patches **3.3.40–3.3.174**. Full per-patch history remains below; this section is the operator-facing **3.4.0** release summary (CI renames `[Unreleased]` on merge to `main`).
+- Stable channel jump from **3.3.39** (previous `main`) through development patches **3.3.40â€“3.3.174**. Full per-patch history remains below; this section is the operator-facing **3.4.0** release summary (CI renames `[Unreleased]` on merge to `main`).
 
 ---
 
-## [3.3.174] — 2026-07-24
+## [3.3.174] â€” 2026-07-24
 
 ### Security
 - Guest WebSocket proxy validates access-link tokens before upgrade; RustDesk OIDC auth-query requires device id/uuid when pending recorded them; `tar` and `golang.org/x/text` bumps for audit/govulncheck.
@@ -480,34 +483,34 @@
 
 ---
 
-## [3.3.173] — 2026-07-24
+## [3.3.173] â€” 2026-07-24
 
 ### Changed
-- Release prep for upcoming stable **3.4.0** (curated notes live under `[Unreleased]` until `dev` → `main` merge).
+- Release prep for upcoming stable **3.4.0** (curated notes live under `[Unreleased]` until `dev` â†’ `main` merge).
 
 ---
 
-## [3.3.172] — 2026-07-24
+## [3.3.172] â€” 2026-07-24
 
 ### Added
-- **OIDC login for stock RustDesk desktop clients (#304):** when panel OIDC is enabled, `GET /api/login-options` advertises `oidc/<display name>`; clients use `POST /api/oidc/auth` + `GET /api/oidc/auth-query` (same IdP config / redirect family as panel SSO). Ships via panel update (Go API restart). Verify: enable OIDC → open RustDesk Login → SSO button appears → complete IdP login → client receives access token.
+- **OIDC login for stock RustDesk desktop clients (#304):** when panel OIDC is enabled, `GET /api/login-options` advertises `oidc/<display name>`; clients use `POST /api/oidc/auth` + `GET /api/oidc/auth-query` (same IdP config / redirect family as panel SSO). Ships via panel update (Go API restart). Verify: enable OIDC â†’ open RustDesk Login â†’ SSO button appears â†’ complete IdP login â†’ client receives access token.
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.171] — 2026-07-24
+## [3.3.171] â€” 2026-07-24
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.170] — 2026-07-24
+## [3.3.170] â€” 2026-07-24
 
 ### Fixed
-- **Fresh Docker install (#299):** `install.sh` default image tag synced to current `VERSION` (was stuck at 3.3.112 while compose/bump used a newer tag); summary falls back to `docker compose exec -u betterdesk … cat .admin_credentials` when `betterdesk-show-admin-credentials` is missing; split layout prints the correct compose service name (`console`). `betterdesk-docker.sh` password reset targets the all-in-one `betterdesk` container on single layout (no longer hardcodes `betterdesk-console`) and runs as UID `betterdesk` so `auth.db` is writable under `cap_drop: ALL`. Legacy split GHCR compose (`docker-compose.quick.yml`) uses `DB_PATH=/opt/rustdesk/db_v2.sqlite3` so the console no longer opens a read-only/orphan peer DB under `console-data` (`SQLITE_READONLY`). All-in-one image: `su-exec` packaged; entrypoint writes `.api_key` / enrollment sentinel as UID `betterdesk` (fresh named volumes inherit image ownership 10001 — root without `CAP_DAC_OVERRIDE` cannot create those files). `betterdesk-show-admin-credentials` falls back to `su` when `su-exec` is absent. `scripts/bump-version.js` now updates `install.sh` pins.
+- **Fresh Docker install (#299):** `install.sh` default image tag synced to current `VERSION` (was stuck at 3.3.112 while compose/bump used a newer tag); summary falls back to `docker compose exec -u betterdesk â€¦ cat .admin_credentials` when `betterdesk-show-admin-credentials` is missing; split layout prints the correct compose service name (`console`). `betterdesk-docker.sh` password reset targets the all-in-one `betterdesk` container on single layout (no longer hardcodes `betterdesk-console`) and runs as UID `betterdesk` so `auth.db` is writable under `cap_drop: ALL`. Legacy split GHCR compose (`docker-compose.quick.yml`) uses `DB_PATH=/opt/rustdesk/db_v2.sqlite3` so the console no longer opens a read-only/orphan peer DB under `console-data` (`SQLITE_READONLY`). All-in-one image: `su-exec` packaged; entrypoint writes `.api_key` / enrollment sentinel as UID `betterdesk` (fresh named volumes inherit image ownership 10001 â€” root without `CAP_DAC_OVERRIDE` cannot create those files). `betterdesk-show-admin-credentials` falls back to `su` when `su-exec` is absent. `scripts/bump-version.js` now updates `install.sh` pins.
 - **Unapproved Managed/Enrollment clients could start outbound sessions (#302):** signal `PunchHoleRequest` / `RequestRelay` now require a live registered initiator. In `managed` / `locked` modes the initiator must also have an approved peer row in the DB (pending enrollment alone is refused). Anonymous rendezvous without registration is blocked in all modes. Ships via panel update (Go signal restart). Stock RustDesk may still show Ready while pending; outbound connect fails until operator approval.
 
 ### Changed
@@ -515,14 +518,14 @@
 
 ---
 
-## [3.3.169] — 2026-07-23
+## [3.3.169] â€” 2026-07-23
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.168] — 2026-07-23
+## [3.3.168] â€” 2026-07-23
 
 ### Fixed
 - **Postgres RustDesk `/api/login` Token generation failed (#300):** `CreateClientSession` no longer scans `RETURNING created_at` (TIMESTAMPTZ) into a Go `string`. INSERT now returns `to_char(... UTC)` like the existing session SELECT paths, so client login on PostgreSQL succeeds. Ships via panel update; restart Go, then sign in once in the RustDesk client.
@@ -533,14 +536,14 @@
 
 ---
 
-## [3.3.167] — 2026-07-22
+## [3.3.167] â€” 2026-07-22
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.166] — 2026-07-22
+## [3.3.166] â€” 2026-07-22
 
 ### Fixed
 - **WSS relay decryption error after PeerInfo / H.265 (#293):** WebSocket relay no longer pipes paired peers through `websocket.NetConn` + `io.Copy`. That path split each large binary frame into ~32 KiB WebSocket messages, so encrypted video failed with `decryption error(0)` while small handshake messages (SignedId, PeerInfo) still worked. Relay now forwards complete WS messages end-to-end (same pattern as MeshCentral WS relay) and raises the WS read limit to 16 MiB.
@@ -551,42 +554,42 @@
 
 ---
 
-## [3.3.165] — 2026-07-22
+## [3.3.165] â€” 2026-07-22
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.164] — 2026-07-22
+## [3.3.164] â€” 2026-07-22
 
 ### Fixed
 - **Signal secure TCP `unhandled type <nil>` (#296):** after KeyExchange, modern clients may send `HttpProxyRequest` (protobuf field 27). The Go signal schema stopped at field 26 (`hc`), so decrypt succeeded but `Union` stayed nil and the connection was closed. Proto now includes `HttpProxyRequest`/`HttpProxyResponse`; the server replies with `error: "not supported"` (no open HTTP egress proxy). Empty encrypted frames are soft-ignored; unknown oneof fields log field numbers instead of opaque `<nil>`.
-- **False MaxListenersExceededWarning on panel WebSocket upgrades (#295):** console WebSocket services now share a single HTTP `upgrade` dispatcher instead of stacking 11 separate listeners (Node's default max is 10). Reconnects never added listeners — the warning was a startup false positive, not a reconnect leak. Session `MemoryStore` remains intentional for the single-process console (shared store is for future multi-instance HA only).
+- **False MaxListenersExceededWarning on panel WebSocket upgrades (#295):** console WebSocket services now share a single HTTP `upgrade` dispatcher instead of stacking 11 separate listeners (Node's default max is 10). Reconnects never added listeners â€” the warning was a startup false positive, not a reconnect leak. Session `MemoryStore` remains intentional for the single-process console (shared store is for future multi-instance HA only).
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.163] — 2026-07-22
+## [3.3.163] â€” 2026-07-22
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.162] — 2026-07-22
+## [3.3.162] â€” 2026-07-22
 
 ### Fixed
-- **OIDC SSO authorize redirect (#298):** clicking “Sign in with OIDC” no longer browser-redirects to the internal Go API URL (`http://localhost:21114/...`). The panel resolves the IdP authorize URL server-to-server and sends the browser only to the identity provider.
+- **OIDC SSO authorize redirect (#298):** clicking â€œSign in with OIDCâ€ no longer browser-redirects to the internal Go API URL (`http://localhost:21114/...`). The panel resolves the IdP authorize URL server-to-server and sends the browser only to the identity provider.
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.161] — 2026-07-22
+## [3.3.161] â€” 2026-07-22
 
 ### Security
 - **Trusted proxy allowlist (#276):** Go signal/API honor `X-Real-IP` / `X-Forwarded-For` only when `TRUST_PROXY=Y` **and** the direct peer is listed in `TRUSTED_PROXIES` (CIDR/IP). Empty allowlist ignores forwarded headers (prevents spoofing if the Go port is reachable). WebSocket initiator delivery uses exact `ip:port` (`wsPunchConns`) so shared-NAT peers no longer receive another client's PunchHole/RelayResponse / signed PK.
@@ -596,35 +599,35 @@
 
 ---
 
-## [3.3.160] — 2026-07-21
+## [3.3.160] â€” 2026-07-21
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.159] — 2026-07-21
+## [3.3.159] â€” 2026-07-21
 
 ### Fixed
-- **Public Client Endpoints survive Docker recreate (#291):** Settings → Public client endpoints now persist on the `console-data` volume (`/app/data/public-endpoints.env`) instead of only ephemeral `/app/.env`. Optional Compose `PUBLIC_*` env vars override when non-empty; empty Compose keys no longer mask saved values.
-- **Mixed WSS / native relay crash (#290):** relay sessions that pair a WebSocket peer (`:21119`) with a native TCP/TLS peer (`:21117`) are rejected instead of forwarding incompatible framings (`invalid message format` / `payload too large`). Signal returns `RefuseReason: Protocol mismatch…` when initiator and target connection types differ (WebSocket Mode vs native).
+- **Public Client Endpoints survive Docker recreate (#291):** Settings â†’ Public client endpoints now persist on the `console-data` volume (`/app/data/public-endpoints.env`) instead of only ephemeral `/app/.env`. Optional Compose `PUBLIC_*` env vars override when non-empty; empty Compose keys no longer mask saved values.
+- **Mixed WSS / native relay crash (#290):** relay sessions that pair a WebSocket peer (`:21119`) with a native TCP/TLS peer (`:21117`) are rejected instead of forwarding incompatible framings (`invalid message format` / `payload too large`). Signal returns `RefuseReason: Protocol mismatchâ€¦` when initiator and target connection types differ (WebSocket Mode vs native).
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.158] — 2026-07-21
+## [3.3.158] â€” 2026-07-21
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.157] — 2026-07-21
+## [3.3.157] â€” 2026-07-21
 
 ### Security
-- **npm audit:** bump `protobufjs` to ≥7.6.5 and override `body-parser` to ≥1.20.6 (DoS advisories).
+- **npm audit:** bump `protobufjs` to â‰¥7.6.5 and override `body-parser` to â‰¥1.20.6 (DoS advisories).
 - **CI:** Secret Scan installs ripgrep before fingerprint script; CodeQL advanced workflow no longer runs on every push (conflicts with GitHub default setup SARIF upload).
 - **Go signal:** keepalive timing overrides use atomics so `-race` tests no longer flake.
 - **Go toolchain:** bump `betterdesk-server` toolchain to `go1.26.5` for govulncheck (GO-2026-5856 / stdlib TLS fixes).
@@ -637,28 +640,28 @@
 
 ---
 
-## [3.3.156] — 2026-07-20
+## [3.3.156] â€” 2026-07-20
 
 ### Security
-- **Dependabot:** bumped `axios` to ≥1.18.0 and `brace-expansion` override to ≥1.1.16 in `web-nodejs` (DoS / prototype-pollution advisories).
-- **CodeQL:** explicit `rdClientPageLimiter` on public mesh share/desktop routes; OIDC session redirect validates configured panel base instead of `HasPrefix`; ConnLimiter int→int32 clamp uses `math.MaxInt32`; clipboard test DOMParser mock uses stable multi-pass strip.
+- **Dependabot:** bumped `axios` to â‰¥1.18.0 and `brace-expansion` override to â‰¥1.1.16 in `web-nodejs` (DoS / prototype-pollution advisories).
+- **CodeQL:** explicit `rdClientPageLimiter` on public mesh share/desktop routes; OIDC session redirect validates configured panel base instead of `HasPrefix`; ConnLimiter intâ†’int32 clamp uses `math.MaxInt32`; clipboard test DOMParser mock uses stable multi-pass strip.
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.155] — 2026-07-20
+## [3.3.155] â€” 2026-07-20
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.154] — 2026-07-20
+## [3.3.154] â€” 2026-07-20
 
 ### Fixed
-- **Guest Web Remote 500 + cookie hijack (#274):** `/remote/guest` no longer crashes during EJS render (guest bootstrap JSON uses the same safe pattern as the viewer). Panel sessions with `device.connect` win over a stale `betterdesk.guest` / `bd.guest` cookie, so operators are not hard-403’d on other device IDs after opening a guest link. Guest cookie is cleared on login and on `GET /remote` dashboard; RD WebSocket upgrades prefer `?guest=` on the session URL.
+- **Guest Web Remote 500 + cookie hijack (#274):** `/remote/guest` no longer crashes during EJS render (guest bootstrap JSON uses the same safe pattern as the viewer). Panel sessions with `device.connect` win over a stale `betterdesk.guest` / `bd.guest` cookie, so operators are not hard-403â€™d on other device IDs after opening a guest link. Guest cookie is cleared on login and on `GET /remote` dashboard; RD WebSocket upgrades prefer `?guest=` on the session URL.
 - **SQLite dual-DB local password for RustDesk client (#260):** startup `backfillFromNode` now copies the panel `password_hash` into missing Go `users` rows instead of creating a random placeholder password, so local panel passwords work for desktop client login without a manual reset.
 
 ### Changed
@@ -666,45 +669,45 @@
 
 ---
 
-## [3.3.153] — 2026-07-20
+## [3.3.153] â€” 2026-07-20
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.152] — 2026-07-20
+## [3.3.152] â€” 2026-07-20
 
 ### Fixed
 - **WebSocket Mode relay timeout behind Nginx (#276 residual):** after the session-key fix, ephemeral WSS `RequestRelay` connections still failed because the signal server sent an immediate empty keepalive after HTTP 101. Desktop clients parse that as `RendezvousMessage{union:None}` and disconnect before `RelayResponse`. Keepalives now start after `RegisterPeer`/`RegisterPk`, or after a short idle delay only when the client has not sent any frame yet. Stale closed `WSConn` handles are cleared on forward failure.
-- **RustDesk address book login “Token generation failed” (#284):** `POST /api/login` now logs the underlying `issueClientSession` error, validates user id before insert, and recreates the `client_sessions` table if a post-update DB was missing the #242 schema. Restart Go after panel update, then sign in once in the RustDesk client.
+- **RustDesk address book login â€œToken generation failedâ€ (#284):** `POST /api/login` now logs the underlying `issueClientSession` error, validates user id before insert, and recreates the `client_sessions` table if a post-update DB was missing the #242 schema. Restart Go after panel update, then sign in once in the RustDesk client.
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.151] — 2026-07-18
+## [3.3.151] â€” 2026-07-18
 
 ### Fixed
-- **Linux installer stale script after update (#219):** after Update replaces `betterdesk.sh` on disk, the interactive manager re-execs itself so Repair / Protocol Toggle use the new post-toggle tests (avoids false `HTTP redirect … on :5000` from the old in-memory script). Recreating systemd units preserves `PORT`/`HTTPS_PORT` from `.env` instead of resetting to `5000`/`5443`. Standard HTTPS (`:443`) post-tests always probe redirect on `:80`.
+- **Linux installer stale script after update (#219):** after Update replaces `betterdesk.sh` on disk, the interactive manager re-execs itself so Repair / Protocol Toggle use the new post-toggle tests (avoids false `HTTP redirect â€¦ on :5000` from the old in-memory script). Recreating systemd units preserves `PORT`/`HTTPS_PORT` from `.env` instead of resetting to `5000`/`5443`. Standard HTTPS (`:443`) post-tests always probe redirect on `:80`.
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.150] — 2026-07-18
+## [3.3.150] â€” 2026-07-18
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.149] — 2026-07-18
+## [3.3.149] â€” 2026-07-18
 
 ### Added
-- **Guest Access Links for Web Remote / RdClient (#274):** operators can create a time-limited opaque link with a device allowlist. Guests open `/remote/guest?t=…`, see only those devices, and cannot use the plus/session-picker/quick-connect paths to reach other peers. No panel Console session is created. Mesh single-device share tunnel auth no longer requires a panel login when `mesh_share` is valid.
+- **Guest Access Links for Web Remote / RdClient (#274):** operators can create a time-limited opaque link with a device allowlist. Guests open `/remote/guest?t=â€¦`, see only those devices, and cannot use the plus/session-picker/quick-connect paths to reach other peers. No panel Console session is created. Mesh single-device share tunnel auth no longer requires a panel login when `mesh_share` is valid.
 
 ### Fixed
 - **Linux HTTP/HTTPS post-toggle false fail (#219):** when the panel uses `HTTPS_PORT=443` / `PORT=80`, post-configuration tests no longer probe a stale `Environment=PORT=5000` from the systemd unit. Effective settings prefer `.env` (matches `EnvironmentFile=` precedence), standard-port repair syncs `PORT`/`HTTPS_PORT` into `betterdesk-console.service`, and redirect checks fall back to `:80` when that listener is active.
@@ -714,17 +717,17 @@
 
 ---
 
-## [3.3.148] — 2026-07-18
+## [3.3.148] â€” 2026-07-18
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.147] — 2026-07-16
+## [3.3.147] â€” 2026-07-16
 
 ### Added
-- **RustDesk client login → device owner (#270):** successful client login maps the device (`peers.user`) to the BetterDesk account for inventory/audit (shared logins, credential misuse). Does **not** block remote connections.
+- **RustDesk client login â†’ device owner (#270):** successful client login maps the device (`peers.user`) to the BetterDesk account for inventory/audit (shared logins, credential misuse). Does **not** block remote connections.
 
 ### Fixed
 - **WebSocket mode behind Nginx (#276):** signal WSS no longer builds session keys as `IP:0` / `[IP:port]:0` from `X-Real-IP` / `X-Forwarded-For`. Forwarded addresses are parsed correctly when `TRUST_PROXY=Y`, and async PunchHole/RelayResponse delivery reaches WebSocket initiators (not only TCP punch connections).
@@ -734,86 +737,86 @@
 
 ---
 
-## [3.3.146] — 2026-07-16
+## [3.3.146] â€” 2026-07-16
 
 ### Fixed
-- **Windows panel update (#272):** default install under `C:\BetterDeskConsole` no longer treats drive root `C:\` as the project root. Installer/Docker files are written beside the console (avoids `EPERM: mkdir 'C:\'`), quick compose filenames are non-critical for SHA tracking, and NSSM `Access is denied` when restarting BetterDeskServer no longer leaves a stuck “updates available” state.
+- **Windows panel update (#272):** default install under `C:\BetterDeskConsole` no longer treats drive root `C:\` as the project root. Installer/Docker files are written beside the console (avoids `EPERM: mkdir 'C:\'`), quick compose filenames are non-critical for SHA tracking, and NSSM `Access is denied` when restarting BetterDeskServer no longer leaves a stuck â€œupdates availableâ€ state.
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.145] — 2026-07-14
+## [3.3.145] â€” 2026-07-14
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.144] — 2026-07-14
+## [3.3.144] â€” 2026-07-14
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.143] — 2026-07-14
+## [3.3.143] â€” 2026-07-14
 
 ### Fixed
 - **External reverse proxy (#267):** wizard asks whether Caddy/Nginx runs on the same host; remote-proxy setups get `HOST=0.0.0.0` and LAN upstream in generated snippets (instead of always `127.0.0.1`).
-- **OIDC SSO login (#269):** after IdP callback on the Go API port, the browser is redirected to the configured **Panel URL** (Settings → Authentication → OIDC) so the Node.js console can create the session cookie. Fixes `Invalid or missing credentials` on Docker / split-port setups. Also preserves post-login return URL from OAuth state and shows OIDC error messages on the login page.
+- **OIDC SSO login (#269):** after IdP callback on the Go API port, the browser is redirected to the configured **Panel URL** (Settings â†’ Authentication â†’ OIDC) so the Node.js console can create the session cookie. Fixes `Invalid or missing credentials` on Docker / split-port setups. Also preserves post-login return URL from OAuth state and shows OIDC error messages on the login page.
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.142] — 2026-07-14
+## [3.3.142] â€” 2026-07-14
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.141] — 2026-07-14
+## [3.3.141] â€” 2026-07-14
 
 ### Added
 - **External reverse proxy guidance (#267):** new [docs/setup/REVERSE_PROXY.md](docs/setup/REVERSE_PROXY.md); `betterdesk.sh` **External reverse proxy** mode (SSL menu **C** / Protocol Toggle **T**) applies `TRUST_PROXY=Y`, binds panel to localhost, enables Go `-trust-proxy`, and writes Caddy/Nginx snippets under `$RUSTDESK_PATH/reverse-proxy/`.
 
 ### Changed
-- **Linux HTTP/HTTPS toggle (#219):** Node panel no longer pre-emptively downgrades `HTTPS_PORT=443` / `PORT=80` when `CAP_NET_BIND_SERVICE` is granted — detects ambient capability or `BETTERDESK_HAS_BIND_SERVICE=1` in the systemd unit. Repair HTTPS/TLS syncs `PORT=80` when `HTTPS_PORT=443`; installer health checks and post-toggle tests hint when the panel bound a fallback port (`:5443` / `:5000`).
+- **Linux HTTP/HTTPS toggle (#219):** Node panel no longer pre-emptively downgrades `HTTPS_PORT=443` / `PORT=80` when `CAP_NET_BIND_SERVICE` is granted â€” detects ambient capability or `BETTERDESK_HAS_BIND_SERVICE=1` in the systemd unit. Repair HTTPS/TLS syncs `PORT=80` when `HTTPS_PORT=443`; installer health checks and post-toggle tests hint when the panel bound a fallback port (`:5443` / `:5000`).
 
 ---
 
-## [3.3.140] — 2026-07-14
+## [3.3.140] â€” 2026-07-14
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.139] — 2026-07-14
+## [3.3.139] â€” 2026-07-14
 
 ### Docs
-- **LDAP operator guide:** `docs/wiki/LDAP-AD.md` — AD setup, RustDesk client login, troubleshooting; cross-links from User Management wiki.
+- **LDAP operator guide:** `docs/wiki/LDAP-AD.md` â€” AD setup, RustDesk client login, troubleshooting; cross-links from User Management wiki.
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.138] — 2026-07-13
+## [3.3.138] â€” 2026-07-13
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.137] — 2026-07-12
+## [3.3.137] â€” 2026-07-12
 
 ### Security
-- **npm (dev):** bumped vitest/vite/esbuild in root and agent-client lockfiles; added `web-nodejs` overrides for `@babel/core` and `js-yaml` (Dependabot alerts #40–#48).
+- **npm (dev):** bumped vitest/vite/esbuild in root and agent-client lockfiles; added `web-nodejs` overrides for `@babel/core` and `js-yaml` (Dependabot alerts #40â€“#48).
 - **CodeQL:** `NewConnLimiterFromInt` for relay per-IP limits; removed dead `deepSet` from `patch-role-scope-i18n.js`; extended Dependabot npm coverage to repo root and agent-client; added `go/incorrect-conversion-between-integer-types` query filter.
 
 ### Changed
@@ -821,14 +824,14 @@
 
 ---
 
-## [3.3.136] — 2026-07-12
+## [3.3.136] â€” 2026-07-12
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.135] — 2026-07-12
+## [3.3.135] â€” 2026-07-12
 
 ### Security
 - **Pre-3.4 hardening:** committed `web-nodejs/package-lock.json`; CI uses `npm ci` and blocks moderate+ npm audit findings; added `govulncheck` (Go), `cargo audit` (Tauri), Dependabot for npm/gomod.
@@ -841,28 +844,28 @@
 
 ---
 
-## [3.3.134] — 2026-07-12
+## [3.3.134] â€” 2026-07-12
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.133] — 2026-07-11
+## [3.3.133] â€” 2026-07-11
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.132] — 2026-07-10
+## [3.3.132] â€” 2026-07-10
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.131] — 2026-07-09
+## [3.3.131] â€” 2026-07-09
 
 ### Security
 - **CodeQL:** advanced setup workflow (`.github/workflows/codeql.yml`) wires `.github/codeql/codeql-config.yml` so documented exclusions apply; `patch-role-scope-i18n.js` hardened against prototype pollution (`UNSAFE_NESTED_KEYS` guard).
@@ -873,17 +876,17 @@
 
 ---
 
-## [3.3.130] — 2026-07-09
+## [3.3.130] â€” 2026-07-09
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.129] — 2026-07-09
+## [3.3.129] â€” 2026-07-09
 
 ### Fixed
-- **RustDesk client sessions (#242):** desktop/mobile clients no longer drop out after ~24 hours. Login now uses DB-backed session tokens (default **7 days**, sliding renewal on activity, max **30 days**). Configure under **Settings → Authentication → RustDesk clients**. Ships via panel update; sign in once in the client after updating.
+- **RustDesk client sessions (#242):** desktop/mobile clients no longer drop out after ~24 hours. Login now uses DB-backed session tokens (default **7 days**, sliding renewal on activity, max **30 days**). Configure under **Settings â†’ Authentication â†’ RustDesk clients**. Ships via panel update; sign in once in the client after updating.
 - **Linux HTTP/HTTPS toggle (#219):** Go server now honours `GO_API_PORT=21114` over shared `.env` `API_PORT=21121` (Node Client API proxy), matching existing `SIGNAL_PORT` isolation. Installer and panel update patch `Environment=GO_API_PORT=21114` on `betterdesk-server.service`; post-toggle tests wait for Go API and hint when handlers leaked to `:21121`.
 
 ### Changed
@@ -891,7 +894,7 @@
 
 ---
 
-## [3.3.128] — 2026-07-09
+## [3.3.128] â€” 2026-07-09
 
 ### Changed
 - _(none yet)_
@@ -901,105 +904,105 @@
 
 ---
 
-## [3.3.127] — 2026-07-09
+## [3.3.127] â€” 2026-07-09
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.126] — 2026-07-07
+## [3.3.126] â€” 2026-07-07
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.125] — 2026-07-07
+## [3.3.125] â€” 2026-07-07
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.124] — 2026-07-07
+## [3.3.124] â€” 2026-07-07
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.123] — 2026-07-07
+## [3.3.123] â€” 2026-07-07
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.122] — 2026-07-07
+## [3.3.122] â€” 2026-07-07
 
 ### Fixed
-- **Linux HTTP/HTTPS toggle (#219)** — `ensure_betterdesk_console_user` no longer prints repair warnings to stdout (they corrupted `User=` in `betterdesk-console.service` → `bad-setting`). Added `repair_console_service_user_line`, unified HTTPS repair on update/toggle, `SIGNAL_PORT=21116` / `RELAY_PORT=21117` in panel update service patch, ExecStartPre exits 0 on LE warnings-only, and port cleanup after graceful stop.
+- **Linux HTTP/HTTPS toggle (#219)** â€” `ensure_betterdesk_console_user` no longer prints repair warnings to stdout (they corrupted `User=` in `betterdesk-console.service` â†’ `bad-setting`). Added `repair_console_service_user_line`, unified HTTPS repair on update/toggle, `SIGNAL_PORT=21116` / `RELAY_PORT=21117` in panel update service patch, ExecStartPre exits 0 on LE warnings-only, and port cleanup after graceful stop.
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.121] — 2026-07-06
+## [3.3.121] â€” 2026-07-06
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.120] — 2026-07-06
+## [3.3.120] â€” 2026-07-06
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.119] — 2026-07-06
+## [3.3.119] â€” 2026-07-06
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.118] — 2026-07-06
+## [3.3.118] â€” 2026-07-06
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.117] — 2026-07-06
+## [3.3.117] â€” 2026-07-06
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.116] — 2026-07-06
+## [3.3.116] â€” 2026-07-06
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.115] — 2026-07-06
+## [3.3.115] â€” 2026-07-06
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.114] — 2026-07-06
+## [3.3.114] â€” 2026-07-06
 
 ### Added
-- **Web Remote — File Transfer drop zone:** left panel shows a drag-and-drop upload box (click to pick files, multi-file supported). Uploads go to the folder currently open on the remote side; progress appears in the Transfers column.
-- **Web Remote — RustDesk file transfer parity:** 128 KB blocks, zstd upload compression, resume via `offset_blk` / `transferred_size`, overwrite confirmation dialog (Skip / Overwrite / apply to all), remote context menu (rename, delete, new folder), hidden-files toggle, and Resume in the transfer queue after errors.
+- **Web Remote â€” File Transfer drop zone:** left panel shows a drag-and-drop upload box (click to pick files, multi-file supported). Uploads go to the folder currently open on the remote side; progress appears in the Transfers column.
+- **Web Remote â€” RustDesk file transfer parity:** 128 KB blocks, zstd upload compression, resume via `offset_blk` / `transferred_size`, overwrite confirmation dialog (Skip / Overwrite / apply to all), remote context menu (rename, delete, new folder), hidden-files toggle, and Resume in the transfer queue after errors.
 - **Panel updater:** GitHub raw file downloads retry automatically on HTTP 429/502/503/504 (exponential backoff), reducing failed locale syncs during large updates.
 
 ### Changed
@@ -1007,42 +1010,42 @@
 
 ---
 
-## [3.3.113] — 2026-07-06
+## [3.3.113] â€” 2026-07-06
 
 ### Changed
-- **Docker — official single container (default):** `install.sh` and quick-start docs now deploy one pre-built image (`ghcr.io/unitronix/betterdesk`) via `docker-compose.quick.single.yml`. Updates are a single `docker compose pull && up -d`. Legacy two-container layout remains available with `install.sh --split` or `docker-compose.quick.yml`. Panel update instructions respect `BETTERDESK_DOCKER_LAYOUT` (`single` vs `split`). Migrating from split to single reuses the same named volumes; RustDesk client API URL changes from port `21114` to `21121`.
+- **Docker â€” official single container (default):** `install.sh` and quick-start docs now deploy one pre-built image (`ghcr.io/unitronix/betterdesk`) via `docker-compose.quick.single.yml`. Updates are a single `docker compose pull && up -d`. Legacy two-container layout remains available with `install.sh --split` or `docker-compose.quick.yml`. Panel update instructions respect `BETTERDESK_DOCKER_LAYOUT` (`single` vs `split`). Migrating from split to single reuses the same named volumes; RustDesk client API URL changes from port `21114` to `21121`.
 
 ---
 
-## [3.3.112] — 2026-07-05
+## [3.3.112] â€” 2026-07-05
 
 ### Fixed
-- **Panel ID change (regression on v3.3.101):** Web Console no longer forces custom device IDs to uppercase — case is preserved end-to-end (`MacPro1` stays `MacPro1`, not `MACPRO1`). After a panel-side rename, the Go signal server redirects heartbeats from the stale client ID to the successor row (preventing duplicate offline/online peer entries) and pushes a `PeerDiscovery` `change_id` notification to connected clients. Panel DB cascade uses the exact case sent to the Go API.
+- **Panel ID change (regression on v3.3.101):** Web Console no longer forces custom device IDs to uppercase â€” case is preserved end-to-end (`MacPro1` stays `MacPro1`, not `MACPRO1`). After a panel-side rename, the Go signal server redirects heartbeats from the stale client ID to the successor row (preventing duplicate offline/online peer entries) and pushes a `PeerDiscovery` `change_id` notification to connected clients. Panel DB cascade uses the exact case sent to the Go API.
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.111] — 2026-07-05
+## [3.3.111] â€” 2026-07-05
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.110] — 2026-07-05
+## [3.3.110] â€” 2026-07-05
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.109] — 2026-07-05
+## [3.3.109] â€” 2026-07-05
 
 ### Fixed
-- **Email/SMTP settings (Fixes #240):** Settings → Email “Test connection” no longer returns HTTP 415 — SMTP save/test/load now use `Utils.api()` so requests include `Content-Type: application/json` required by panel API middleware.
-- **Panel tabs redirect to dashboard (401):** RustDesk client API routes (`GET /api/devices`, `/api/strategies`) no longer shadow panel session routes — browser requests without Bearer token fall through to panel handlers; `users.js` uses `/api/panel/strategies`; `Utils.api` no longer redirects logged-in users to `/login` (which bounced to dashboard) on incidental 401.
+- **Email/SMTP settings (Fixes #240):** Settings â†’ Email â€œTest connectionâ€ no longer returns HTTP 415 â€” SMTP save/test/load now use `Utils.api()` so requests include `Content-Type: application/json` required by panel API middleware.
+- **Panel tabs redirect to dashboard (401):** RustDesk client API routes (`GET /api/devices`, `/api/strategies`) no longer shadow panel session routes â€” browser requests without Bearer token fall through to panel handlers; `users.js` uses `/api/panel/strategies`; `Utils.api` no longer redirects logged-in users to `/login` (which bounced to dashboard) on incidental 401.
 - **Devices/Users 429 rate limit:** extended panel poll whitelist (`/api/folders`, `/api/tags`, `/api/device-groups`, `/api/bd/notifications`, `/api/panel/*`); dedicated limiter for `POST /api/desktop/layout`; staggered Devices page API loads; desktop widget layout saves gated when desktop mode is inactive.
 
 ### Changed
@@ -1050,157 +1053,157 @@
 
 ---
 
-## [3.3.108] — 2026-07-05
+## [3.3.108] â€” 2026-07-05
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.107] — 2026-07-05
+## [3.3.107] â€” 2026-07-05
 
 ### Fixed
-- **Server Admin navigation:** `server_admin` can open sidebar pages gated by `server.config` (Policies, Attestation, DataGuard, Generator, Users) — routes no longer require legacy `admin`/`global_admin` only; 403 template fixed for role checks; stale desktop-mode overlay cleared on load.
-- **Dashboard 429 rate limit:** panel poll endpoints (`/api/dashboard/client-config`, activity, widgets, stats, etc.) now use the higher widget quota and no longer consume the 100/min general API budget — fixes `Too Many Requests` on dashboard load/refresh.
+- **Server Admin navigation:** `server_admin` can open sidebar pages gated by `server.config` (Policies, Attestation, DataGuard, Generator, Users) â€” routes no longer require legacy `admin`/`global_admin` only; 403 template fixed for role checks; stale desktop-mode overlay cleared on load.
+- **Dashboard 429 rate limit:** panel poll endpoints (`/api/dashboard/client-config`, activity, widgets, stats, etc.) now use the higher widget quota and no longer consume the 100/min general API budget â€” fixes `Too Many Requests` on dashboard load/refresh.
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.106] — 2026-07-05
+## [3.3.106] â€” 2026-07-05
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.105] — 2026-07-05
+## [3.3.105] â€” 2026-07-05
 
 ### Added
 - **User scope UX (#227):** User Management now assigns **folders**, **direct devices**, and **RustDesk Pro strategies** per user; effective device count badge; folder ACL supports **allowed user groups**; optional **restricted default visibility** in Settings (`DEVICE_SCOPE_DEFAULT` / panel setting); docs [SCOPED_REMOTE_USER.md](docs/features/SCOPED_REMOTE_USER.md) and draft GitHub reply.
 
 ### Changed
-- **Role labels (UI only):** `operator` → “Remote Operator”, `pro` → “Pro License (client API only)”; dynamic role descriptions and scope hints in user form (all 26 locales).
+- **Role labels (UI only):** `operator` â†’ â€œRemote Operatorâ€, `pro` â†’ â€œPro License (client API only)â€; dynamic role descriptions and scope hints in user form (all 26 locales).
 
 ---
 
-## [3.3.104] — 2026-07-05
+## [3.3.104] â€” 2026-07-05
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.103] — 2026-07-05
+## [3.3.103] â€” 2026-07-05
 
 ### Fixed
-- **Device ID change (#213):** RustDesk 1.4.x client rename works again — the server accepts `RegisterPk` ID-change requests with an empty PK (stock client wire format) instead of returning `NOT_SUPPORT` / “Not yet supported by the server”.
+- **Device ID change (#213):** RustDesk 1.4.x client rename works again â€” the server accepts `RegisterPk` ID-change requests with an empty PK (stock client wire format) instead of returning `NOT_SUPPORT` / â€œNot yet supported by the serverâ€.
 - **Panel ID change:** Permanent delete now clears `id_change_history` so released IDs can be reused; panel/API ID changes cascade to enrollment tokens, org assignments, and linked peers; renamed-ID registration allows the same device (matching IP or PK/UUID) to stay connected after a panel-side rename.
-- **Panel sync:** Go `peer_id_changed` events now cascade panel DB rows in real time; periodic Go→panel sync applies client-side renames; hard delete purges stale panel `peer` rows; BD-API `/register` uses the same identity-aware rename guard as the signal server.
+- **Panel sync:** Go `peer_id_changed` events now cascade panel DB rows in real time; periodic Goâ†’panel sync applies client-side renames; hard delete purges stale panel `peer` rows; BD-API `/register` uses the same identity-aware rename guard as the signal server.
 
 ### Changed
 - **Panel UX:** Device list reloads on live ID-change events; online-device warning before change-ID from both list and detail views.
 - **RustDesk Pro parity:** Panel strategies manager on Devices page; org address book structured editor; `/api/device-group/accessible` returns accessible payload (matches Go); Go API supports `POST /api/device-group`, strategy update/delete; device detail panel receives live status and ID-change events.
-- **RustDesk Pro strategy assign:** Direct device/user/device-group strategy assignments via `POST /api/strategies/assign`, `GET /api/strategies/{guid}`, `PUT /api/strategies/{guid}/status`, and `GET /api/devices` (id + guid); panel UI “Assign targets” on the strategies manager; BetterDesk Go server mirrors the same endpoints.
+- **RustDesk Pro strategy assign:** Direct device/user/device-group strategy assignments via `POST /api/strategies/assign`, `GET /api/strategies/{guid}`, `PUT /api/strategies/{guid}/status`, and `GET /api/devices` (id + guid); panel UI â€œAssign targetsâ€ on the strategies manager; BetterDesk Go server mirrors the same endpoints.
 
 ---
 
-## [3.3.102] — 2026-07-04
+## [3.3.102] â€” 2026-07-04
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.101] — 2026-07-04
+## [3.3.101] â€” 2026-07-04
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.100] — 2026-07-04
+## [3.3.100] â€” 2026-07-04
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.99] — 2026-07-04
+## [3.3.99] â€” 2026-07-04
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.98] — 2026-07-04
+## [3.3.98] â€” 2026-07-04
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.97] — 2026-07-04
+## [3.3.97] â€” 2026-07-04
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.96] — 2026-07-04
+## [3.3.96] â€” 2026-07-04
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.95] — 2026-07-04
+## [3.3.95] â€” 2026-07-04
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.94] — 2026-07-04
+## [3.3.94] â€” 2026-07-04
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.93] — 2026-07-03
+## [3.3.93] â€” 2026-07-03
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.92] — 2026-07-03
+## [3.3.92] â€” 2026-07-03
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.91] — 2026-07-03
+## [3.3.91] â€” 2026-07-03
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.90] — 2026-07-03
+## [3.3.90] â€” 2026-07-03
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.89] — 2026-07-03
+## [3.3.89] â€” 2026-07-03
 
 ### Fixed
-- **Linux HTTP/HTTPS toggle (#219)** — `betterdesk-server.service` now sets `SIGNAL_PORT=21116` / `RELAY_PORT=21117` so panel `PORT=5000` in `.env` no longer makes the Go signal server bind `:5000` (conflict with the HTTPS redirect listener). Let's Encrypt redeploy removes same-path symlinks before `cp` (`cp: same file`). New **Repair → Repair HTTPS / TLS** menu path runs stuck-state repair (LE copy + signal ports); post-toggle tests wait for Go on `:21116` and surface the `:5000` mis-bind hint.
+- **Linux HTTP/HTTPS toggle (#219)** â€” `betterdesk-server.service` now sets `SIGNAL_PORT=21116` / `RELAY_PORT=21117` so panel `PORT=5000` in `.env` no longer makes the Go signal server bind `:5000` (conflict with the HTTPS redirect listener). Let's Encrypt redeploy removes same-path symlinks before `cp` (`cp: same file`). New **Repair â†’ Repair HTTPS / TLS** menu path runs stuck-state repair (LE copy + signal ports); post-toggle tests wait for Go on `:21116` and surface the `:5000` mis-bind hint.
 - **Deleted device ID management (#213):** Devices list now has a **Show deleted devices** toggle. Soft-deleted rows can be **Restored** or **permanently deleted** (releases the ID for reuse). Hard delete works for already-soft-deleted peers; change-ID conflicts map to a clear panel message instead of a generic server error.
 
 ### Changed
@@ -1208,69 +1211,69 @@
 
 ---
 
-## [3.3.88] — 2026-07-03
+## [3.3.88] â€” 2026-07-03
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.87] — 2026-07-01
+## [3.3.87] â€” 2026-07-01
 
 ### Fixed
-- **RustDesk desktop WSS immediate EOF on `/ws/id`** — The Go signal WebSocket endpoint now sends an immediate empty keepalive frame after HTTP 101, honours `X-Forwarded-For` / `X-Real-IP` on upgrade, binds `WSConn` on `RegisterPeer`, and supports `WS_DEBUG_FRAMES=1` for first-frame diagnostics. Reported in ([#229](https://github.com/UNITRONIX/BetterDesk/issues/229)).
+- **RustDesk desktop WSS immediate EOF on `/ws/id`** â€” The Go signal WebSocket endpoint now sends an immediate empty keepalive frame after HTTP 101, honours `X-Forwarded-For` / `X-Real-IP` on upgrade, binds `WSConn` on `RegisterPeer`, and supports `WS_DEBUG_FRAMES=1` for first-frame diagnostics. Reported in ([#229](https://github.com/UNITRONIX/BetterDesk/issues/229)).
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.86] — 2026-06-30
+## [3.3.86] â€” 2026-06-30
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.85] — 2026-06-30
+## [3.3.85] â€” 2026-06-30
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.84] — 2026-06-30
+## [3.3.84] â€” 2026-06-30
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.83] — 2026-06-30
+## [3.3.83] â€” 2026-06-30
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.82] — 2026-06-30
+## [3.3.82] â€” 2026-06-30
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.81] — 2026-06-30
+## [3.3.81] â€” 2026-06-30
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.80] — 2026-06-29
+## [3.3.80] â€” 2026-06-29
 
 ### Fixed
-- **Linux HTTP/HTTPS toggle hotfix (#219)**: `linux-ensure-console-user.js` contained a bash syntax fragment (`if [ -z ...`) that crashed the console on every start — fixed. LE repair also resolves the certbot live dir from the certificate SAN when `LE_CERT_LIVE_DIR` is missing.
+- **Linux HTTP/HTTPS toggle hotfix (#219)**: `linux-ensure-console-user.js` contained a bash syntax fragment (`if [ -z ...`) that crashed the console on every start â€” fixed. LE repair also resolves the certbot live dir from the certificate SAN when `LE_CERT_LIVE_DIR` is missing.
 - **Linux HTTP/HTTPS toggle follow-up (#219)**: panel updates and `betterdesk.sh` updates re-run Let's Encrypt TLS repair; SSL menu (C) unified with Protocol Toggle (T); post-toggle tests wait for Node boot.
 
 ### Changed
@@ -1278,24 +1281,24 @@
 
 ---
 
-## [3.3.79] — 2026-06-28
+## [3.3.79] â€” 2026-06-28
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.78] — 2026-06-28
+## [3.3.78] â€” 2026-06-28
 
 ### Fixed
-- **Linux Let's Encrypt HTTPS toggle (#219)**: `betterdesk.sh` now **copies** certbot material into `$RUSTDESK_PATH/ssl/` (real files with `root:betterdesk` permissions) instead of symlinking into `/etc/letsencrypt/` — the console service user could not read LE private keys and silently fell back to HTTP on `:5000`. Certbot deploy hook re-copies renewed certs; `ensure_betterdesk_console_user` repairs legacy symlink installs; post-toggle tests verify the console user can read the TLS key.
+- **Linux Let's Encrypt HTTPS toggle (#219)**: `betterdesk.sh` now **copies** certbot material into `$RUSTDESK_PATH/ssl/` (real files with `root:betterdesk` permissions) instead of symlinking into `/etc/letsencrypt/` â€” the console service user could not read LE private keys and silently fell back to HTTP on `:5000`. Certbot deploy hook re-copies renewed certs; `ensure_betterdesk_console_user` repairs legacy symlink installs; post-toggle tests verify the console user can read the TLS key.
 
 ### Changed
 - **Sensitive data anonymization**: removed operator-specific LAN IP, SSH user, and developer paths from public docs and examples; operator deploy runbooks moved to gitignored `docs/private/`; security contact updated; CI checks block regression (`scripts/check-no-sensitive-paths.sh`, `.gitleaks.toml`).
 
 ---
 
-## [3.3.77] — 2026-06-27
+## [3.3.77] â€” 2026-06-27
 
 ### Fixed
 - **Organization device groups (#221)**: editing a device group from the Devices page (e.g. switching to automatic tag membership) no longer clears `team_id`, so groups stay linked to their organization and org-scoped access is preserved.
@@ -1305,66 +1308,66 @@
 
 ---
 
-## [3.3.76] — 2026-06-27
+## [3.3.76] â€” 2026-06-27
 
 ### Fixed
-- **Public RustDesk client endpoints (#222)**: Dashboard client configuration, QR codes, deploy strings, and Keys page now honor `PUBLIC_SERVER_ID`, `PUBLIC_RELAY_SERVER`, and `PUBLIC_API_URL` when the console hostname differs from ID/relay/API (reverse proxy / split DNS). Settings → Public client endpoints edits `.env` without a console restart. `PANEL_PUBLIC_HOST` and Dashboard **Client server address** remain as fallbacks.
+- **Public RustDesk client endpoints (#222)**: Dashboard client configuration, QR codes, deploy strings, and Keys page now honor `PUBLIC_SERVER_ID`, `PUBLIC_RELAY_SERVER`, and `PUBLIC_API_URL` when the console hostname differs from ID/relay/API (reverse proxy / split DNS). Settings â†’ Public client endpoints edits `.env` without a console restart. `PANEL_PUBLIC_HOST` and Dashboard **Client server address** remain as fallbacks.
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.75] — 2026-06-27
+## [3.3.75] â€” 2026-06-27
 
 ### Fixed
-- **NTP servers for billing clock (#223)**: `betterdesk-server` now loads `NTP_SERVERS` and billing clock vars from console `.env` (Linux `EnvironmentFile` + update migration). Added `BILLING_TRUST_OS_NTP` fallback when OS time sync is healthy but public NTP is blocked. Commercialization → Settings exposes NTP configuration with Go server restart.
+- **NTP servers for billing clock (#223)**: `betterdesk-server` now loads `NTP_SERVERS` and billing clock vars from console `.env` (Linux `EnvironmentFile` + update migration). Added `BILLING_TRUST_OS_NTP` fallback when OS time sync is healthy but public NTP is blocked. Commercialization â†’ Settings exposes NTP configuration with Go server restart.
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.74] — 2026-06-27
+## [3.3.74] â€” 2026-06-27
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.73] — 2026-06-26
+## [3.3.73] â€” 2026-06-26
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.72] — 2026-06-26
+## [3.3.72] â€” 2026-06-26
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.71] — 2026-06-26
+## [3.3.71] â€” 2026-06-26
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.70] — 2026-06-26
+## [3.3.70] â€” 2026-06-26
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.69] — 2026-06-26
+## [3.3.69] â€” 2026-06-26
 
 ### Fixed
 - **Web Remote file transfer (#217)**: upload now sends the full destination file path (not just the directory); downloads default to the browser Downloads folder; transfer queue shows phases, progress, cancel, and stall timeout; drag-and-drop overlay on the remote panel; optional local folder save via File System Access when chosen.
-- **Web Remote file transfer protocol (#217)**: fix inverted RustDesk FileAction mapping — download uses `send` (full remote path), upload uses `receive` (remote dir + FileEntry); upload sends `send_confirm` before blocks; optional zstd block decompress on download.
+- **Web Remote file transfer protocol (#217)**: fix inverted RustDesk FileAction mapping â€” download uses `send` (full remote path), upload uses `receive` (remote dir + FileEntry); upload sends `send_confirm` before blocks; optional zstd block decompress on download.
 - **Panel update sudoers bootstrap (Linux)**: `linux-ensure-console-user.js` is whitelisted in sudoers and invoked via passwordless sudo during updates; server binary deploy refreshes sudoers as root so new privileged helpers (e.g. `linux-write-systemd-unit.js`) apply without a manual root step.
 
 ### Changed
@@ -1372,43 +1375,43 @@
 
 ---
 
-## [3.3.68] — 2026-06-26
+## [3.3.68] â€” 2026-06-26
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.67] — 2026-06-26
+## [3.3.67] â€” 2026-06-26
 
 ### Fixed
 - **OIDC SSO login (#225)**: panel callback now calls the missing `exchangeOIDCCode` Go API client method so one-time auth codes are exchanged server-to-server after IdP redirect (fixes `TypeError: betterdeskApi.exchangeOIDCCode is not a function`).
-- **RdClient desktop (#226)**: Windows build — pass `&str` to WebView2 `additional_browser_args` (fixes compile error after GPU/media args refactor).
+- **RdClient desktop (#226)**: Windows build â€” pass `&str` to WebView2 `additional_browser_args` (fixes compile error after GPU/media args refactor).
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.66] — 2026-06-24
+## [3.3.66] â€” 2026-06-24
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.65] — 2026-06-24
+## [3.3.65] â€” 2026-06-24
 
 ### Fixed
 - **Web Remote file transfer (#217)**: opens a dedicated `FILE_TRANSFER` relay session (separate from the desktop tunnel) so RustDesk peers handle `FileAction` messages. Replaces the side panel with a RustDesk-style centered modal (local | remote | transfer queue); local folder browsing uses the File System Access API on Chrome/Edge with HTTPS fallback. CDAP snapshot sessions disable the file-transfer toolbar button.
 - **Panel update systemd unit patch (Linux)**: service config cleanup no longer calls interactive `sudo tee`; uses a whitelisted passwordless-sudo helper for `betterdesk-server.service` / `betterdesk-console.service` after `linux-ensure-console-user.js` refreshes sudoers.
 
 ### Changed
-- **Web Remote toolbar UX**: hides “Connected” status text and frame count while streaming; removes the in-viewer language picker. Fullscreen (toolbar button, handle, F11) now covers the tab bar, viewer, and floating toolbar via `#rd-viewer-shell`.
+- **Web Remote toolbar UX**: hides â€œConnectedâ€ status text and frame count while streaming; removes the in-viewer language picker. Fullscreen (toolbar button, handle, F11) now covers the tab bar, viewer, and floating toolbar via `#rd-viewer-shell`.
 
 ---
 
-## [3.3.64] — 2026-06-24
+## [3.3.64] â€” 2026-06-24
 
 ### Fixed
 - **RustDesk client LDAP login (#218)**: `POST /api/login` on the Go API now uses the same provider-bound LDAP/AD authentication as the web console (`/api/auth/login`). LDAP-bound and auto-provisioned directory users can sign in to the RustDesk desktop client with domain username/password; TOTP still applies when enabled locally.
@@ -1418,34 +1421,34 @@
 
 ---
 
-## [3.3.63] — 2026-06-24
+## [3.3.63] â€” 2026-06-24
 
 ### Fixed
-- **Linux HTTP/HTTPS protocol toggle (#219)**: `betterdesk.sh` now syncs `.env` and `betterdesk-console.service` consistently (`RUSTDESK_API_TLS`, SSL paths, redirect flags); health checks use `HTTPS_PORT` (5443) instead of conflating with `PORT` (5000); post-toggle tests probe Client API with the correct scheme. Panel HTTP→HTTPS redirect uses 307 + `no-store`; HSTS is skipped when `ALLOW_SELF_SIGNED_CERTS=true` so toggling back to HTTP does not leave year-long browser enforcement.
+- **Linux HTTP/HTTPS protocol toggle (#219)**: `betterdesk.sh` now syncs `.env` and `betterdesk-console.service` consistently (`RUSTDESK_API_TLS`, SSL paths, redirect flags); health checks use `HTTPS_PORT` (5443) instead of conflating with `PORT` (5000); post-toggle tests probe Client API with the correct scheme. Panel HTTPâ†’HTTPS redirect uses 307 + `no-store`; HSTS is skipped when `ALLOW_SELF_SIGNED_CERTS=true` so toggling back to HTTP does not leave year-long browser enforcement.
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.62] — 2026-06-22
+## [3.3.62] â€” 2026-06-22
 
 ### Fixed
-- **RdClient Web phone gate**: fixed mobile device detection that blocked access on PC, tablets, and unfolded foldables with “Remote desktop requires a larger screen”. Gate now respects `[hidden]`, skips zero-width false positives, excludes fine-pointer desktops, and re-evaluates on viewport resize. Ships via Settings → Updates.
+- **RdClient Web phone gate**: fixed mobile device detection that blocked access on PC, tablets, and unfolded foldables with â€œRemote desktop requires a larger screenâ€. Gate now respects `[hidden]`, skips zero-width false positives, excludes fine-pointer desktops, and re-evaluates on viewport resize. Ships via Settings â†’ Updates.
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.61] — 2026-06-21
+## [3.3.61] â€” 2026-06-21
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.60] — 2026-06-21
+## [3.3.60] â€” 2026-06-21
 
 ### Changed
 - **Mesh layer closure**: `MESH_ENABLED=Y` default in Go config; installers (`betterdesk.sh` / `betterdesk.ps1`) and panel updater inject `MESH_ENABLED=Y` on existing Linux/Windows services; mesh cert backup on update.
@@ -1455,7 +1458,7 @@
 
 ---
 
-## [3.3.59] — 2026-06-21
+## [3.3.59] â€” 2026-06-21
 
 ### Added
 - **MeshCentral compatibility layer** (optional `MESH_ENABLED=Y`): native Go implementation of `/agent.ashx`, `/meshrelay.ashx`, and `/control.ashx` for unmodified MeshAgent binaries; unified inventory with `mesh_agent` device type; rdclient web `transport=mesh`; REST helpers (`/api/mesh/*`, `POST /api/peers/{id}/exec`); panel `.msh` download and `.ashx` WebSocket proxy. See [docs/features/MESHAGENT_ONBOARDING.md](docs/features/MESHAGENT_ONBOARDING.md).
@@ -1463,214 +1466,214 @@
 ### Changed
 - **Mesh agent assets**: AGPL **BetterCore** (`bettercore.js`) and **BetterViewer** (`betterviewer.js`) replace vendored upstream MeshCentral JavaScript.
 - **BetterCore phase 2**: consent prompts, WebRTC tunnel handoff, PowerShell terminals (`p=6`/`p=9`); interop CI with simulated handshake + live MeshAgent binary job.
-- **Mesh operator tools**: guest desktop share links (`mesh_share`), TCP/UDP port relay (`POST /api/mesh/devices/{id}/tcp` / `udp`), device power actions (sleep/reset), session recording to `.mcrec`, Settings → MeshCentral section, linked-peer UX in device menu.
+- **Mesh operator tools**: guest desktop share links (`mesh_share`), TCP/UDP port relay (`POST /api/mesh/devices/{id}/tcp` / `udp`), device power actions (sleep/reset), session recording to `.mcrec`, Settings â†’ MeshCentral section, linked-peer UX in device menu.
 
 ---
 
-## [3.3.58] — 2026-06-21
+## [3.3.58] â€” 2026-06-21
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.57] — 2026-06-21
+## [3.3.57] â€” 2026-06-21
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.56] — 2026-06-20
+## [3.3.56] â€” 2026-06-20
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.55] — 2026-06-20
+## [3.3.55] â€” 2026-06-20
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.54] — 2026-06-20
+## [3.3.54] â€” 2026-06-20
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.53] — 2026-06-20
+## [3.3.53] â€” 2026-06-20
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.52] — 2026-06-20
+## [3.3.52] â€” 2026-06-20
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.51] — 2026-06-20
+## [3.3.51] â€” 2026-06-20
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.50] — 2026-06-20
+## [3.3.50] â€” 2026-06-20
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.49] — 2026-06-20
+## [3.3.49] â€” 2026-06-20
 
 ### Changed
 - RustDesk mass-deployment docs and dashboard helpers for Intune/PSADT: correct `--config` deploy string format, editable client server address, **Copy deploy string** / **Intune script** on Dashboard, `PANEL_PUBLIC_HOST` env, and `scripts/deploy/rustdesk-apply-config.ps1.example` (#209).
 
 ---
 
-## [3.3.48] — 2026-06-20
+## [3.3.48] â€” 2026-06-20
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.47] — 2026-06-20
+## [3.3.47] â€” 2026-06-20
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.46] — 2026-06-20
+## [3.3.46] â€” 2026-06-20
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.45] — 2026-06-20
+## [3.3.45] â€” 2026-06-20
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.44] — 2026-06-20
+## [3.3.44] â€” 2026-06-20
 
 ### Changed
 - Hardened RustDesk client change-ID handling so only the active owner of the old ID can rename it, and soft-deleted device IDs remain reserved instead of being moved by client-side ID changes (#213).
 
 ---
 
-## [3.3.43] — 2026-06-20
+## [3.3.43] â€” 2026-06-20
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.42] — 2026-06-20
+## [3.3.42] â€” 2026-06-20
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.41] — 2026-06-20
+## [3.3.41] â€” 2026-06-20
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.40] — 2026-06-20
+## [3.3.40] â€” 2026-06-20
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.39] — 2026-06-19
+## [3.3.39] â€” 2026-06-19
 
 ### Changed
 - **Organization shared address book panel (#190):** the organization detail page now exposes the missing Address Book tab, including JSON editing, sharing toggle, and import from assigned org devices. Members still receive the shared contacts through RustDesk address book sync while personal entries remain private.
 
 ---
 
-## [3.3.38] — 2026-06-18
+## [3.3.38] â€” 2026-06-18
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.37] — 2026-06-18
+## [3.3.37] â€” 2026-06-18
 
 ### Changed
 - **Docker admin password seeding (#204):** `ADMIN_PASSWORD` now maps to the internal Go and Node.js first-run admin seed variables in quick-start, MACVLAN, and single-container Docker deployments. Existing admin accounts are still left unchanged on restart; use the password reset flow or fresh volumes to change an already-created admin.
 
 ---
 
-## [3.3.36] — 2026-06-18
+## [3.3.36] â€” 2026-06-18
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.35] — 2026-06-18
+## [3.3.35] â€” 2026-06-18
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.34] — 2026-06-18
+## [3.3.34] â€” 2026-06-18
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.33] — 2026-06-18
+## [3.3.33] â€” 2026-06-18
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.32] — 2026-06-18
+## [3.3.32] â€” 2026-06-18
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.31] — 2026-06-18
+## [3.3.31] â€” 2026-06-18
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.30] — 2026-06-18
+## [3.3.30] â€” 2026-06-18
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.29] — 2026-06-18
+## [3.3.29] â€” 2026-06-18
 
 ### Fixed
 - **Device ID reuse after deletion (#213):** changing a device ID to a value reserved by a soft-deleted peer now returns a clear conflict instead of a generic server error. The panel also explains that normal delete keeps the ID reserved and offers permanent deletion when an operator intentionally wants to release the ID for reuse.
@@ -1680,56 +1683,56 @@
 
 ---
 
-## [3.3.28] — 2026-06-17
+## [3.3.28] â€” 2026-06-17
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.27] — 2026-06-17
+## [3.3.27] â€” 2026-06-17
 
 ### Fixed
 - **Web Console CI / dependency audit:** bump `nodemailer`, `multer`, `ws`, and transitive `form-data` minimums so `npm audit --omit=dev --audit-level=high` passes on the release branch.
 
 ---
 
-## [3.3.26] — 2026-06-17
+## [3.3.26] â€” 2026-06-17
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.25] — 2026-06-17
+## [3.3.25] â€” 2026-06-17
 
 ### Fixed
-- **RustDesk client login with console 2FA (#203)** — console password changes now mirror to the Go user store, and SQLite installs mirror console TOTP enable/disable state into the Go `users` row used by `/api/login`. RustDesk clients should now receive the expected `email_check` / `tfa_check` challenge instead of `Invalid credentials` or password-only login when console 2FA is enabled. No TOTP bypass endpoint was added.
+- **RustDesk client login with console 2FA (#203)** â€” console password changes now mirror to the Go user store, and SQLite installs mirror console TOTP enable/disable state into the Go `users` row used by `/api/login`. RustDesk clients should now receive the expected `email_check` / `tfa_check` challenge instead of `Invalid credentials` or password-only login when console 2FA is enabled. No TOTP bypass endpoint was added.
 
 ---
 
-## [3.3.24] — 2026-06-17
+## [3.3.24] â€” 2026-06-17
 
 ### Fixed
-- **Bare-metal console startup (#206)** — `betterdesk-console` failed with `SQLITE_READONLY_DIRECTORY` on `db_v2.sqlite3` because the unprivileged `betterdesk` user could not write to the Go server data directory. Installer and `linux-ensure-console-user.js` now apply setgid group-write on `$RUSTDESK_PATH`, re-sync permissions after the Go server starts, and verify both console `data/` and Go data dirs before marking permissions OK. **Verify:** `systemctl status betterdesk-console` is `active`; panel loads on port 5000 or 5443. Ships via Settings → Updates or `betterdesk.sh` update/repair.
+- **Bare-metal console startup (#206)** â€” `betterdesk-console` failed with `SQLITE_READONLY_DIRECTORY` on `db_v2.sqlite3` because the unprivileged `betterdesk` user could not write to the Go server data directory. Installer and `linux-ensure-console-user.js` now apply setgid group-write on `$RUSTDESK_PATH`, re-sync permissions after the Go server starts, and verify both console `data/` and Go data dirs before marking permissions OK. **Verify:** `systemctl status betterdesk-console` is `active`; panel loads on port 5000 or 5443. Ships via Settings â†’ Updates or `betterdesk.sh` update/repair.
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.23] — 2026-06-15
+## [3.3.23] â€” 2026-06-15
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.22] — 2026-06-14
+## [3.3.22] â€” 2026-06-14
 
 ### Added
 
-- **RdClient desktop (production hardening):** server URL validation via `GET /api/bd/server-info` and `probe_server_url`; extended `config.json` (`tls_strict`, `ui_lang`, `discovered_via`); `BETTERDESK_SERVER_URL` env and embedded `betterdesk-rdclient.json` on first launch; LAN discovery (UDP port 21119 + optional mDNS `_betterdesk._tcp`); local **Settings** window (change URL, TLS, sign out, factory reset); peer **Remember device password** vault (IndexedDB AES-GCM per device); language switcher on `/remote/login`, dashboard, and viewer (26 locales); **Generator → RdClient desktop** bundles with `rdclientBuildWorker` (6 platform variants, embedded panel URL).
+- **RdClient desktop (production hardening):** server URL validation via `GET /api/bd/server-info` and `probe_server_url`; extended `config.json` (`tls_strict`, `ui_lang`, `discovered_via`); `BETTERDESK_SERVER_URL` env and embedded `betterdesk-rdclient.json` on first launch; LAN discovery (UDP port 21119 + optional mDNS `_betterdesk._tcp`); local **Settings** window (change URL, TLS, sign out, factory reset); peer **Remember device password** vault (IndexedDB AES-GCM per device); language switcher on `/remote/login`, dashboard, and viewer (26 locales); **Generator â†’ RdClient desktop** bundles with `rdclientBuildWorker` (6 platform variants, embedded panel URL).
 
 ### Changed
 
@@ -1738,24 +1741,24 @@
 
 ### Manual steps (build host)
 
-- RdClient installer builds require **Rust stable**, **npm**, **@tauri-apps/cli**, and Linux deps (`webkit2gtk4.1-devel`, `openssl-devel`, …) on the panel build host. Optional: `npm install bonjour-service` in `web-nodejs` for mDNS panel publish (`PANEL_MDNS=off` to disable).
+- RdClient installer builds require **Rust stable**, **npm**, **@tauri-apps/cli**, and Linux deps (`webkit2gtk4.1-devel`, `openssl-devel`, â€¦) on the panel build host. Optional: `npm install bonjour-service` in `web-nodejs` for mDNS panel publish (`PANEL_MDNS=off` to disable).
 
 ---
 
-## [3.3.21] — 2026-06-14
+## [3.3.21] â€” 2026-06-14
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.20] — 2026-06-14
+## [3.3.20] â€” 2026-06-14
 
 ### Fixed
 
 - **RdClient dashboard (web):** address book and sidebar scroll inside fixed columns with hidden scrollbars; `.rd-desk-content` flex chain fixed so the device grid no longer stretches the window.
 - **RdClient video (AV1):** WebKit uses software AV1 decode; agent `codec_string` is passed to `VideoDecoder`; AV1 keyframes build `description` (av1C); failed codecs auto-reconnect with VP9/H.264.
-- **RdClient desktop:** **Connect** from the loaded `/remote` dashboard — runtime ACL for the configured panel origin (fixes LAN IP:port invoke), injected Connect bridge in the desktop shell (works before panel JS update), correct Tauri invoke args (`deviceId` / `deviceName`), and a new app window loading the same `/remote/:id` viewer as the web panel; session window **Back** closes the desktop window (injected handler + no `/devices` fallback).
+- **RdClient desktop:** **Connect** from the loaded `/remote` dashboard â€” runtime ACL for the configured panel origin (fixes LAN IP:port invoke), injected Connect bridge in the desktop shell (works before panel JS update), correct Tauri invoke args (`deviceId` / `deviceName`), and a new app window loading the same `/remote/:id` viewer as the web panel; session window **Back** closes the desktop window (injected handler + no `/devices` fallback).
 - **RdClient desktop (performance):** Linux Wayland keeps WebKit DMA-BUF/GPU compositing enabled by default; vendor-specific VA-API (Intel `iHD`, AMD `radeonsi`, NVIDIA when `nvidia-vaapi-driver` is present); GStreamer hardware decoder rank for AV1/H264/VP9/H265; session windows disable background throttling; Windows WebView2 AV1/HEVC GPU decode flags; WebCodecs probes multiple AV1/H264 profiles for WebKitGTK compatibility.
 
 ### Changed
@@ -1763,37 +1766,37 @@
 
 ---
 
-## [3.3.19] — 2026-06-14
+## [3.3.19] â€” 2026-06-14
 
 ### Added
 
-- **RdClient desktop (Phase C — MVP):** new `rdclient-desktop/` Tauri v2 operator shell — first-run panel URL setup, main window loads `{url}/remote`, **Connect** opens a separate session window (`/remote/:id`); web dashboard uses `open_session` when `__TAURI__` is present. **Linux:** automatic X11/Wayland session detection and WebKitGTK workarounds (Gdk error 71 on Wayland). **TLS:** accepts **HTTP** and **HTTPS** with self-signed, Let's Encrypt, or incomplete-chain certs (operator panels); set `BETTERDESK_TLS_STRICT=1` for strict system CA validation only. Not yet distributed via Settings → Updates (build from source).
+- **RdClient desktop (Phase C â€” MVP):** new `rdclient-desktop/` Tauri v2 operator shell â€” first-run panel URL setup, main window loads `{url}/remote`, **Connect** opens a separate session window (`/remote/:id`); web dashboard uses `open_session` when `__TAURI__` is present. **Linux:** automatic X11/Wayland session detection and WebKitGTK workarounds (Gdk error 71 on Wayland). **TLS:** accepts **HTTP** and **HTTPS** with self-signed, Let's Encrypt, or incomplete-chain certs (operator panels); set `BETTERDESK_TLS_STRICT=1` for strict system CA validation only. Not yet distributed via Settings â†’ Updates (build from source).
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.18] — 2026-06-14
+## [3.3.18] â€” 2026-06-14
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.17] — 2026-06-14
+## [3.3.17] â€” 2026-06-14
 
 ### Added
 
-- **RdClient dashboard (web):** **Tools → Remote Desktop** opens `/remote` in a new browser tab — standalone operator address book with folders, device groups, tags, quick-connect by ID, card grid (RustDesk-inspired layout), list toggle, 30s auto-sync, panel branding/fonts/colors. Devices → Web Remote unchanged.
-- **RdClient login (web):** `/remote/login` — dedicated operator sign-in when the panel session expires (redirects to `/remote` or viewer instead of admin `/login`); optional **Remember me** stores encrypted credentials in IndexedDB (Web Crypto AES-GCM), separate from the peer password vault planned for Phase B.
+- **RdClient dashboard (web):** **Tools â†’ Remote Desktop** opens `/remote` in a new browser tab â€” standalone operator address book with folders, device groups, tags, quick-connect by ID, card grid (RustDesk-inspired layout), list toggle, 30s auto-sync, panel branding/fonts/colors. Devices â†’ Web Remote unchanged.
+- **RdClient login (web):** `/remote/login` â€” dedicated operator sign-in when the panel session expires (redirects to `/remote` or viewer instead of admin `/login`); optional **Remember me** stores encrypted credentials in IndexedDB (Web Crypto AES-GCM), separate from the peer password vault planned for Phase B.
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.16] — 2026-06-14
+## [3.3.16] â€” 2026-06-14
 
 ### Changed
 
@@ -1812,7 +1815,7 @@
 
 ---
 
-## [3.3.15] — 2026-06-14
+## [3.3.15] â€” 2026-06-14
 
 ### Changed
 
@@ -1821,82 +1824,82 @@
 
 ---
 
-## [3.3.14] — 2026-06-14
+## [3.3.14] â€” 2026-06-14
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.13] — 2026-06-14
+## [3.3.13] â€” 2026-06-14
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.12] — 2026-06-14
+## [3.3.12] â€” 2026-06-14
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.11] — 2026-06-14
+## [3.3.11] â€” 2026-06-14
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.10] — 2026-06-14
+## [3.3.10] â€” 2026-06-14
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.9] — 2026-06-14
+## [3.3.9] â€” 2026-06-14
 
 ### Added
 
-- **Settings → Appearance (branding):** Modular studio layout with live preview panel, autosave, server-side appearance profiles, built-in theme gallery, Google Fonts picker (expanded catalog), custom font upload (woff2/ttf), and dynamic branding CSS at `/css/branding.css` (fixes theme overrides not applying when static `theme.css` took precedence).
+- **Settings â†’ Appearance (branding):** Modular studio layout with live preview panel, autosave, server-side appearance profiles, built-in theme gallery, Google Fonts picker (expanded catalog), custom font upload (woff2/ttf), and dynamic branding CSS at `/css/branding.css` (fixes theme overrides not applying when static `theme.css` took precedence).
 
 ### Changed
 
-- **Appearance tab:** Changes apply without full page reload; optional “preview on this page” toggle; read-only mode when the user lacks `branding.edit`.
+- **Appearance tab:** Changes apply without full page reload; optional â€œpreview on this pageâ€ toggle; read-only mode when the user lacks `branding.edit`.
 
 ---
 
-## [3.3.8] — 2026-06-14
-
-### Changed
-- _(none yet)_
-
----
-
-## [3.3.7] — 2026-06-14
+## [3.3.8] â€” 2026-06-14
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.6] — 2026-06-14
+## [3.3.7] â€” 2026-06-14
+
+### Changed
+- _(none yet)_
+
+---
+
+## [3.3.6] â€” 2026-06-14
 
 ### Added
 
-- **Email notifications:** SMTP configuration moved to **Settings → Email** (host, credentials, from address, alert/warning email). Each panel user can have an **email address** in User Management (used for routing notifications).
-- **Help request emails:** When a device submits a help request, operators assigned to the device **folder or device group** receive an email (configurable under **Commercialization → Advanced settings**). Falls back to the alert email when no operator address is available. Requires `nodemailer` (now a declared dependency).
+- **Email notifications:** SMTP configuration moved to **Settings â†’ Email** (host, credentials, from address, alert/warning email). Each panel user can have an **email address** in User Management (used for routing notifications).
+- **Help request emails:** When a device submits a help request, operators assigned to the device **folder or device group** receive an email (configurable under **Commercialization â†’ Advanced settings**). Falls back to the alert email when no operator address is available. Requires `nodemailer` (now a declared dependency).
 
 ### Changed
 
-- **Automation:** SMTP tab removed; use **Settings → Email** instead. Legacy `/api/automation/smtp*` endpoints still proxy to the shared SMTP handlers for one release cycle.
+- **Automation:** SMTP tab removed; use **Settings â†’ Email** instead. Legacy `/api/automation/smtp*` endpoints still proxy to the shared SMTP handlers for one release cycle.
 - **Console layout:** Main content now uses the full workspace width (removed the 1400px cap on all panel pages). Device details open as a large workspace modal between the sidebar and the right edge instead of a 640px slide-over from the viewport edge.
 
 ---
 
-## [3.3.5] — 2026-06-14
+## [3.3.5] â€” 2026-06-14
 
 ### Changed
 
@@ -1904,14 +1907,14 @@
 
 ---
 
-## [3.3.4] — 2026-06-14
+## [3.3.4] â€” 2026-06-14
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.3] — 2026-06-13
+## [3.3.3] â€” 2026-06-13
 
 ### Changed
 
@@ -1920,21 +1923,21 @@
 
 ---
 
-## [3.3.2] — 2026-06-12
+## [3.3.2] â€” 2026-06-12
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.3.1] — 2026-06-12
+## [3.3.1] â€” 2026-06-12
 
-Patch release on `main`. Ships via **Settings → Updates** (Stable), `betterdesk.sh` option 2, or replace `betterdesk.sh` from tag `v3.3.1`.
+Patch release on `main`. Ships via **Settings â†’ Updates** (Stable), `betterdesk.sh` option 2, or replace `betterdesk.sh` from tag `v3.3.1`.
 
 ### Fixed
 
-- **`betterdesk.sh` syntax error on Linux (#199)** — removed orphan `fi` in `update_from_github()` (line 3405) that broke `./betterdesk.sh` on v3.3.0 fresh clone and after self-update.
-- **Update via `betterdesk.sh` (#198)** — existing installs no longer show the misleading “Creating admin user” / PANEL LOGIN CREDENTIALS banner; post-update path runs console permission sync and `systemctl reset-failed` before restart; panel health check uses HTTPS/custom `PORT` (not hard-coded `:5000`).
+- **`betterdesk.sh` syntax error on Linux (#199)** â€” removed orphan `fi` in `update_from_github()` (line 3405) that broke `./betterdesk.sh` on v3.3.0 fresh clone and after self-update.
+- **Update via `betterdesk.sh` (#198)** â€” existing installs no longer show the misleading â€œCreating admin userâ€ / PANEL LOGIN CREDENTIALS banner; post-update path runs console permission sync and `systemctl reset-failed` before restart; panel health check uses HTTPS/custom `PORT` (not hard-coded `:5000`).
 
 ### Upgrade notes
 
@@ -1945,22 +1948,22 @@ Patch release on `main`. Ships via **Settings → Updates** (Stable), `betterdes
 
 ---
 
-## [3.3.0] — 2026-06-12
+## [3.3.0] â€” 2026-06-12
 
-Stable production release on `main` (merged from `dev`). Ships via **Settings → Updates** on the **Stable** channel, or `betterdesk.sh` / `betterdesk.ps1` option 2 / `docker compose pull` for GHCR. Panel update creates a pre-update backup by default. No database migration or manual SQL step is required.
+Stable production release on `main` (merged from `dev`). Ships via **Settings â†’ Updates** on the **Stable** channel, or `betterdesk.sh` / `betterdesk.ps1` option 2 / `docker compose pull` for GHCR. Panel update creates a pre-update backup by default. No database migration or manual SQL step is required.
 
 ### Added
 
-- **Organization shared address book (#190)** — admins maintain a shared contact list per organization (Organizations → Address Book). Entries merge into each member's RustDesk address book on `GET /api/ab` when sharing is enabled; personal entries stay private.
-- **Organizations → Device Groups tab** — readout of device groups and user groups linked to the organization (`team_id`), with shortcuts to Devices → Groups and one-click org-scoped group creation.
-- **Docker MACVLAN quick-start (#186)** — `docker-compose.quick.macvlan.yml` plus upgrade notes in [DOCKER_QUICKSTART.md](docs/docker/DOCKER_QUICKSTART.md). Uses `service_started` (not `service_healthy`) and `127.0.0.1` API/WS env when the console uses `network_mode: service:server`.
-- **`betterdesk-show-admin-credentials` helper (#195)** — re-execs as `betterdesk` to read `.admin_credentials` on hardened images (`cap_drop: ALL`). Bundled in all Docker images; documented in README, install.sh, and Docker troubleshooting.
+- **Organization shared address book (#190)** â€” admins maintain a shared contact list per organization (Organizations â†’ Address Book). Entries merge into each member's RustDesk address book on `GET /api/ab` when sharing is enabled; personal entries stay private.
+- **Organizations â†’ Device Groups tab** â€” readout of device groups and user groups linked to the organization (`team_id`), with shortcuts to Devices â†’ Groups and one-click org-scoped group creation.
+- **Docker MACVLAN quick-start (#186)** â€” `docker-compose.quick.macvlan.yml` plus upgrade notes in [DOCKER_QUICKSTART.md](docs/docker/DOCKER_QUICKSTART.md). Uses `service_started` (not `service_healthy`) and `127.0.0.1` API/WS env when the console uses `network_mode: service:server`.
+- **`betterdesk-show-admin-credentials` helper (#195)** â€” re-execs as `betterdesk` to read `.admin_credentials` on hardened images (`cap_drop: ALL`). Bundled in all Docker images; documented in README, install.sh, and Docker troubleshooting.
 
 ### Fixed
 
-- **Stale update warning banner (#192)** — Settings → Updates no longer keeps showing stale `EACCES` errors after a successful external update (`betterdesk.sh`, `betterdesk.ps1`, `betterdesk-docker.sh`, or GHCR `docker compose pull`). Non-critical root-owned file failures are filtered; the banner clears when the installed SHA matches the target. Native install/update now copies `VERSION` into the console directory (Settings reads semver from `VERSION` or `package.json`).
-- **CodeQL / security hardening** — OIDC discovery blocks private/link-local DNS; branding SVG/CSS multi-pass sanitization; same-origin restrictions on desktop iframe routes and `Utils.api()`; confined filesystem helpers; upload rate limits; type-safe device file API parsing. CodeQL config documents intentional exclusions.
-- **Go server product version in Docker builds** — `BETTERDESK_PRODUCT_VERSION` build arg embeds semver in the Go binary (Settings → Server Information matches panel version after image update).
+- **Stale update warning banner (#192)** â€” Settings â†’ Updates no longer keeps showing stale `EACCES` errors after a successful external update (`betterdesk.sh`, `betterdesk.ps1`, `betterdesk-docker.sh`, or GHCR `docker compose pull`). Non-critical root-owned file failures are filtered; the banner clears when the installed SHA matches the target. Native install/update now copies `VERSION` into the console directory (Settings reads semver from `VERSION` or `package.json`).
+- **CodeQL / security hardening** â€” OIDC discovery blocks private/link-local DNS; branding SVG/CSS multi-pass sanitization; same-origin restrictions on desktop iframe routes and `Utils.api()`; confined filesystem helpers; upload rate limits; type-safe device file API parsing. CodeQL config documents intentional exclusions.
+- **Go server product version in Docker builds** â€” `BETTERDESK_PRODUCT_VERSION` build arg embeds semver in the Go binary (Settings â†’ Server Information matches panel version after image update).
 
 ### Changed
 
@@ -1971,377 +1974,377 @@ Stable production release on `main` (merged from `dev`). Ships via **Settings �
 
 | Topic | Action |
 |-------|--------|
-| **Native / panel update** | Settings → Updates → Stable → Check for updates → Install. Allow Go server rebuild/restart when prompted. |
+| **Native / panel update** | Settings â†’ Updates â†’ Stable â†’ Check for updates â†’ Install. Allow Go server rebuild/restart when prompted. |
 | **Docker** | `docker compose pull && docker compose up -d` after release; use `betterdesk-show-admin-credentials` instead of `cat` as root. |
 | **MACVLAN (#186)** | Switch to `docker-compose.quick.macvlan.yml` or set `depends_on: service_started`, `DB_PATH=/app/data/db_v2.sqlite3`, `127.0.0.1` for API/WS. |
 | **Stale update banner (#192)** | Update to 3.3.0+ or once: `rm -f <console-path>/data/.last_update_result.json` and restart console. |
 
 ---
 
-## [3.2.20] — 2026-06-12
+## [3.2.20] â€” 2026-06-12
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.2.19] — 2026-06-12
+## [3.2.19] â€” 2026-06-12
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.2.18] — 2026-06-12
+## [3.2.18] â€” 2026-06-12
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.2.17] — 2026-06-12
+## [3.2.17] â€” 2026-06-12
 
 ### Fixed
-- **Docker admin credential lookup (#195)** — `docker compose exec` as root could not read `.admin_credentials` (mode 0600) on hardened images (`cap_drop: ALL`). Added `betterdesk-show-admin-credentials` helper (re-execs as `betterdesk`); updated README, quick-start compose comments, `install.sh`, and Docker docs. Existing installs without the helper can use `docker compose exec -u betterdesk console …`.
+- **Docker admin credential lookup (#195)** â€” `docker compose exec` as root could not read `.admin_credentials` (mode 0600) on hardened images (`cap_drop: ALL`). Added `betterdesk-show-admin-credentials` helper (re-execs as `betterdesk`); updated README, quick-start compose comments, `install.sh`, and Docker docs. Existing installs without the helper can use `docker compose exec -u betterdesk console â€¦`.
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.2.16] — 2026-06-11
+## [3.2.16] â€” 2026-06-11
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.2.15] — 2026-06-11
+## [3.2.15] â€” 2026-06-11
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.2.14] — 2026-06-11
+## [3.2.14] â€” 2026-06-11
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.2.13] — 2026-06-11
+## [3.2.13] â€” 2026-06-11
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.2.12] — 2026-06-11
+## [3.2.12] â€” 2026-06-11
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.2.11] — 2026-06-11
+## [3.2.11] â€” 2026-06-11
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.2.10] — 2026-06-11
+## [3.2.10] â€” 2026-06-11
 
 ### Fixed
-- **CodeQL / security scan hardening** — OIDC discovery fetch blocks private/link-local DNS targets; branding SVG/CSS sanitization uses stable multi-pass stripping; desktop iframe routes and client `Utils.api()` restricted to same-origin paths; confined filesystem helpers for backups/server file browser/i18n; unbiased password generation; upload rate limits on tickets/languages/file-transfer; type-safe device file API body parsing. CodeQL config excludes dev-only scripts and documents intentional RustDesk wire-protocol hashes.
+- **CodeQL / security scan hardening** â€” OIDC discovery fetch blocks private/link-local DNS targets; branding SVG/CSS sanitization uses stable multi-pass stripping; desktop iframe routes and client `Utils.api()` restricted to same-origin paths; confined filesystem helpers for backups/server file browser/i18n; unbiased password generation; upload rate limits on tickets/languages/file-transfer; type-safe device file API body parsing. CodeQL config excludes dev-only scripts and documents intentional RustDesk wire-protocol hashes.
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.2.9] — 2026-06-11
+## [3.2.9] â€” 2026-06-11
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.2.8] — 2026-06-11
+## [3.2.8] â€” 2026-06-11
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.2.7] — 2026-06-11
+## [3.2.7] â€” 2026-06-11
 
 ### Fixed
-- **Stale update warning on script / Docker paths (#192)** — `betterdesk.ps1` and `betterdesk-docker.sh` now clear `data/.last_update_result.json` when syncing `.update_sha` after a successful external update (parity with `betterdesk.sh`). GHCR image deployments clear the same stale panel banner on console startup after `docker compose pull`.
+- **Stale update warning on script / Docker paths (#192)** â€” `betterdesk.ps1` and `betterdesk-docker.sh` now clear `data/.last_update_result.json` when syncing `.update_sha` after a successful external update (parity with `betterdesk.sh`). GHCR image deployments clear the same stale panel banner on console startup after `docker compose pull`.
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.2.6] — 2026-06-10
+## [3.2.6] â€” 2026-06-10
 
 ### Fixed
-- **Docker MACVLAN quick-start (issue #186)** — Added `docker-compose.quick.macvlan.yml` and MACVLAN upgrade notes in `docs/docker/DOCKER_QUICKSTART.md`. Documents `service_started` (not `service_healthy`) and `127.0.0.1` API/WS env when the console uses `network_mode: service:server`.
+- **Docker MACVLAN quick-start (issue #186)** â€” Added `docker-compose.quick.macvlan.yml` and MACVLAN upgrade notes in `docs/docker/DOCKER_QUICKSTART.md`. Documents `service_started` (not `service_healthy`) and `127.0.0.1` API/WS env when the console uses `network_mode: service:server`.
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.2.5] — 2026-06-10
+## [3.2.5] â€” 2026-06-10
 
 ### Fixed
-- **Panel update warning banner (#192)** — Settings → Updates no longer keeps showing stale `EACCES` errors after a successful `betterdesk.sh` update. Non-critical root-owned file failures (scripts, Dockerfiles, server source) are filtered out; the banner clears automatically when the installed SHA matches the update target.
+- **Panel update warning banner (#192)** â€” Settings â†’ Updates no longer keeps showing stale `EACCES` errors after a successful `betterdesk.sh` update. Non-critical root-owned file failures (scripts, Dockerfiles, server source) are filtered out; the banner clears automatically when the installed SHA matches the update target.
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.2.4] — 2026-06-10
+## [3.2.4] â€” 2026-06-10
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.2.3] — 2026-06-10
+## [3.2.3] â€” 2026-06-10
 
 ### Added
-- **Organization shared address book** — admins can maintain a shared contact list per organization (Organizations → Address Book tab). Entries are merged into each member's RustDesk address book on `GET /api/ab` when sharing is enabled. Personal address book entries remain private and editable only by the logged-in user. Fixes [#190](https://github.com/UNITRONIX/BetterDesk/issues/190).
+- **Organization shared address book** â€” admins can maintain a shared contact list per organization (Organizations â†’ Address Book tab). Entries are merged into each member's RustDesk address book on `GET /api/ab` when sharing is enabled. Personal address book entries remain private and editable only by the logged-in user. Fixes [#190](https://github.com/UNITRONIX/BetterDesk/issues/190).
 
 ### Changed
-- **Organizations → Device Groups tab** — replaced the manual JSON address book editor with a readout of device groups and user groups linked to the organization (`team_id`). Includes a shortcut to Devices → Groups and a one-click “Create device group” action scoped to the org.
+- **Organizations â†’ Device Groups tab** â€” replaced the manual JSON address book editor with a readout of device groups and user groups linked to the organization (`team_id`). Includes a shortcut to Devices â†’ Groups and a one-click â€œCreate device groupâ€ action scoped to the org.
 
 ---
 
-## [3.2.2] — 2026-06-10
-
-### Changed
-- _(none yet)_
-
----
-
-## [3.2.1] — 2026-06-10
+## [3.2.2] â€” 2026-06-10
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.2.0] — 2026-06-10
+## [3.2.1] â€” 2026-06-10
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.1.15] — 2026-06-09
+## [3.2.0] â€” 2026-06-10
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.1.14] — 2026-06-09
+## [3.1.15] â€” 2026-06-09
 
-Production release **3.2.0** (stable `main`). Ships via **Settings → Updates** on the **Stable** channel, or `betterdesk.sh` / `betterdesk.ps1` option 2. Panel update creates a pre-update backup by default. No database migration or manual SQL step is required.
+### Changed
+- _(none yet)_
+
+---
+
+## [3.1.14] â€” 2026-06-09
+
+Production release **3.2.0** (stable `main`). Ships via **Settings â†’ Updates** on the **Stable** channel, or `betterdesk.sh` / `betterdesk.ps1` option 2. Panel update creates a pre-update backup by default. No database migration or manual SQL step is required.
 
 ### Security
 
-- **CVE-2026-50575 / GHSA-3v82-3gf8-fxx8 (device replay after delete)** — WebSocket signal registration now rejects soft-deleted peer IDs (new registration and heartbeat), matching UDP/TCP. `UpdatePeerStatus` no longer marks soft-deleted rows `ONLINE`. Restoration is explicit only via `POST /api/peers/{id}/restore` or the Devices UI. Requires **`betterdesk-server`** update (panel rebuild/redeploy when Go sources change).
-- **Dependency updates** — `go-ntlmssp` 0.1.1 (CVE-2026-32952), `golang.org/x/image` 0.38.0 (CVE-2026-33809), `pgx/v5` 5.9.2 in Go modules; `openssl` 0.10.80 and `tauri` 2.11.2 in Tauri `Cargo.lock` (**desktop client rebuild required** for Rust-side fixes; server/console panel update alone is not enough for desktop).
-- **Go API proxy hardening** — shared `goApiProxy.js` validates path segments on fleet, commercialization, and cross-platform routes; ID guards on all proxy routes; blocks path-smuggling while accepting RustDesk peer IDs (`a-zA-Z0-9_-`).
-- **Go API SSRF guard** — `goApiPath` validates relative paths on the `betterdeskApi` client; policy routes validate org/device IDs; help-request IDs validated before proxying to Go.
-- **XSS** — `cross-platform.js`, `users.js`, `dataguard.js`, `cdap-studio.js` escape/sanitize dynamic HTML and CSS class names.
-- **Path confinement** — shared `safePath` for backup deletion, i18n language files, server file browser, `fontService`, and `fileTransferService` (symlink-aware root checks). File browser respects `BETTERDESK_FILE_ALLOWED_ROOTS`.
-- **SSRF / shell hardening** — OIDC discovery URLs validated before fetch; network monitor HTTP/TCP checks use validated hostname/port/path; terminal proxy restricted to known system shell paths; `updateService` and deploy helpers use `execFileSync` argv arrays; `linux-ensure-console-user.js` uses `execFileSync`.
-- **Clear-text logging** — admin password no longer logged on first install; API login logs redact usernames (`logRedact.js`); admin self-test password cleared after use in `authService`.
-- **Audit log** — `Recent` / `RecentByAction` clamp `n` to 500 to limit allocation.
-- **CI** — `build.yml` default `permissions: contents: read`; write only on release/binary-update jobs.
+- **CVE-2026-50575 / GHSA-3v82-3gf8-fxx8 (device replay after delete)** â€” WebSocket signal registration now rejects soft-deleted peer IDs (new registration and heartbeat), matching UDP/TCP. `UpdatePeerStatus` no longer marks soft-deleted rows `ONLINE`. Restoration is explicit only via `POST /api/peers/{id}/restore` or the Devices UI. Requires **`betterdesk-server`** update (panel rebuild/redeploy when Go sources change).
+- **Dependency updates** â€” `go-ntlmssp` 0.1.1 (CVE-2026-32952), `golang.org/x/image` 0.38.0 (CVE-2026-33809), `pgx/v5` 5.9.2 in Go modules; `openssl` 0.10.80 and `tauri` 2.11.2 in Tauri `Cargo.lock` (**desktop client rebuild required** for Rust-side fixes; server/console panel update alone is not enough for desktop).
+- **Go API proxy hardening** â€” shared `goApiProxy.js` validates path segments on fleet, commercialization, and cross-platform routes; ID guards on all proxy routes; blocks path-smuggling while accepting RustDesk peer IDs (`a-zA-Z0-9_-`).
+- **Go API SSRF guard** â€” `goApiPath` validates relative paths on the `betterdeskApi` client; policy routes validate org/device IDs; help-request IDs validated before proxying to Go.
+- **XSS** â€” `cross-platform.js`, `users.js`, `dataguard.js`, `cdap-studio.js` escape/sanitize dynamic HTML and CSS class names.
+- **Path confinement** â€” shared `safePath` for backup deletion, i18n language files, server file browser, `fontService`, and `fileTransferService` (symlink-aware root checks). File browser respects `BETTERDESK_FILE_ALLOWED_ROOTS`.
+- **SSRF / shell hardening** â€” OIDC discovery URLs validated before fetch; network monitor HTTP/TCP checks use validated hostname/port/path; terminal proxy restricted to known system shell paths; `updateService` and deploy helpers use `execFileSync` argv arrays; `linux-ensure-console-user.js` uses `execFileSync`.
+- **Clear-text logging** â€” admin password no longer logged on first install; API login logs redact usernames (`logRedact.js`); admin self-test password cleared after use in `authService`.
+- **Audit log** â€” `Recent` / `RecentByAction` clamp `n` to 500 to limit allocation.
+- **CI** â€” `build.yml` default `permissions: contents: read`; write only on release/binary-update jobs.
 
 ### Fixed
 
-- **RBAC** — deleting the last `super_admin` / legacy admin is blocked (HTTP 409), aligned with update/demotion guards; org owner label shown as **Org Admin** in all 26 locales.
-- **Panel update (dev channel)** — repair step no longer re-downloads removed `web-nodejs/scripts/*` paths (404 false failures after dev-only i18n toolkit move).
-- **Console update channel UX** — `Modal.confirm` for channel switch dialog; clearer Stable / Development labels and Docker update UI strings in all locales.
-- **Go server deploy (Linux panel)** — privileged Go server binary deploy from the Linux panel (hotfix already on `main`).
+- **RBAC** â€” deleting the last `super_admin` / legacy admin is blocked (HTTP 409), aligned with update/demotion guards; org owner label shown as **Org Admin** in all 26 locales.
+- **Panel update (dev channel)** â€” repair step no longer re-downloads removed `web-nodejs/scripts/*` paths (404 false failures after dev-only i18n toolkit move).
+- **Console update channel UX** â€” `Modal.confirm` for channel switch dialog; clearer Stable / Development labels and Docker update UI strings in all locales.
+- **Go server deploy (Linux panel)** â€” privileged Go server binary deploy from the Linux panel (hotfix already on `main`).
 
 ### Added
 
-- **One-line Linux installer (`install.sh`)** — `curl -fsSL …/install.sh | sudo bash` for automated Docker quick-start (engine install when missing, compose download with validation, relay IP detection, firewall rules, health wait, credential summary). Use `--native` for git clone + `betterdesk.sh --auto`, or `--uninstall` / `--purge` to tear down the Docker stack.
+- **One-line Linux installer (`install.sh`)** â€” `curl -fsSL â€¦/install.sh | sudo bash` for automated Docker quick-start (engine install when missing, compose download with validation, relay IP detection, firewall rules, health wait, credential summary). Use `--native` for git clone + `betterdesk.sh --auto`, or `--uninstall` / `--purge` to tear down the Docker stack.
 
 ### Changed
 
-- **i18n dev toolkit** moved to `web-nodejs/scripts/dev-i18n/` — not deployed to production consoles; one-shot `patch-*` scripts removed (recoverable from git history).
-- **Update channel switcher** — stable vs development channel selection in Settings → Updates (production servers should stay on Stable).
+- **i18n dev toolkit** moved to `web-nodejs/scripts/dev-i18n/` â€” not deployed to production consoles; one-shot `patch-*` scripts removed (recoverable from git history).
+- **Update channel switcher** â€” stable vs development channel selection in Settings â†’ Updates (production servers should stay on Stable).
 
 ### Upgrade notes (operators)
 
 | Topic | Action |
 |-------|--------|
-| **Native / panel update** | Settings → Updates → Stable → Check for updates → Install. Allow Go server rebuild/restart when prompted. |
+| **Native / panel update** | Settings â†’ Updates â†’ Stable â†’ Check for updates â†’ Install. Allow Go server rebuild/restart when prompted. |
 | **Docker** | Pull new GHCR tags after release (`docker compose pull && docker compose up -d`); in-app GitHub install is disabled in container mode. |
 | **Soft-deleted devices** | Do not expect deleted peers to self re-register over WebSocket; use **Restore** in Devices if intentional. |
 | **Custom file paths** | If file browser or font upload breaks, review `BETTERDESK_FILE_ALLOWED_ROOTS` in console `.env`. |
 | **Desktop client (Tauri)** | Rebuild/reinstall desktop agent after this release to pick up `openssl` / `tauri` lockfile fixes. |
-| **Rollback** | Use the automatic pre-update backup from Settings → Updates, or restore from your own snapshot. |
+| **Rollback** | Use the automatic pre-update backup from Settings â†’ Updates, or restore from your own snapshot. |
 
 ### Verify after update
 
 1. Panel login and dashboard load.
-2. Settings → Updates shows current version; no repair 404 errors.
+2. Settings â†’ Updates shows current version; no repair 404 errors.
 3. Devices list and one test remote session.
-4. Optional: delete-user guard — last admin cannot be removed (409).
+4. Optional: delete-user guard â€” last admin cannot be removed (409).
 5. Docker operators: confirm new image tag on GHCR matches `v3.2.0`.
 
 ---
 
-## [3.1.13] — 2026-06-09
+## [3.1.13] â€” 2026-06-09
 
 ### Fixed
-- **RBAC** — deleting the last `super_admin` is blocked (409), aligned with update/demotion guards; org owner label shown as Org Admin in all locales.
-- **Panel update (dev channel)** — repair step no longer re-downloads removed `web-nodejs/scripts/*` paths (404 false failures).
-- **Console update channel UX** — `Modal.confirm` for channel switch dialog; clearer stable/dev labels.
+- **RBAC** â€” deleting the last `super_admin` is blocked (409), aligned with update/demotion guards; org owner label shown as Org Admin in all locales.
+- **Panel update (dev channel)** â€” repair step no longer re-downloads removed `web-nodejs/scripts/*` paths (404 false failures).
+- **Console update channel UX** â€” `Modal.confirm` for channel switch dialog; clearer stable/dev labels.
 
 ### Security
-- **CVE-2026-50575 / GHSA-3v82-3gf8-fxx8 (device replay after delete)** — WebSocket signal registration rejects soft-deleted peer IDs; `UpdatePeerStatus` no longer marks soft-deleted rows `ONLINE`. Restoration via `POST /api/peers/{id}/restore` only. Ships via panel update (`betterdesk-server`).
-- **Dependency updates** — `go-ntlmssp` 0.1.1 (CVE-2026-32952), `golang.org/x/image` 0.38.0 (CVE-2026-33809), `pgx/v5` 5.9.2; `openssl` 0.10.80 and `tauri` 2.11.2 in Tauri `Cargo.lock` (desktop client rebuild required for Rust-side fixes).
-- **Go API proxy hardening (phases D–E)** — shared `goApiProxy.js` validates path segments on fleet, commercialization, and cross-platform routes; ID guards on all proxy routes; blocks path-smuggling while accepting RustDesk peer IDs.
-- **Go API SSRF guard** — `goApiPath` validates all relative paths on `betterdeskApi` axios client; policy routes validate org/device IDs; help-request IDs validated before proxying.
-- **XSS** — `cross-platform.js`, `users.js`, `dataguard.js`, `cdap-studio.js` escape/sanitize dynamic HTML and CSS class names.
-- **Path confinement (CodeQL)** — shared `safePath` helper for backup deletion, i18n language files, server file browser, `fontService`, and `fileTransferService` (symlink-aware root checks).
-- **SSRF / shell hardening** — OIDC discovery URLs validated before fetch; network monitor HTTP/TCP checks use validated components; terminal proxy restricted to known shell paths; `updateService` and deploy helpers use `execFileSync` argv arrays; `linux-ensure-console-user.js` uses `execFileSync`.
-- **Clear-text logging** — admin password no longer logged on first install; API login logs redact usernames (`logRedact.js`); admin self-test password cleared after use.
-- **Audit log** — `Recent` / `RecentByAction` clamp `n` to 500 to limit allocation (CodeQL).
-- **CI** — `build.yml` default `permissions: contents: read`; write only on release/binary-update jobs.
+- **CVE-2026-50575 / GHSA-3v82-3gf8-fxx8 (device replay after delete)** â€” WebSocket signal registration rejects soft-deleted peer IDs; `UpdatePeerStatus` no longer marks soft-deleted rows `ONLINE`. Restoration via `POST /api/peers/{id}/restore` only. Ships via panel update (`betterdesk-server`).
+- **Dependency updates** â€” `go-ntlmssp` 0.1.1 (CVE-2026-32952), `golang.org/x/image` 0.38.0 (CVE-2026-33809), `pgx/v5` 5.9.2; `openssl` 0.10.80 and `tauri` 2.11.2 in Tauri `Cargo.lock` (desktop client rebuild required for Rust-side fixes).
+- **Go API proxy hardening (phases Dâ€“E)** â€” shared `goApiProxy.js` validates path segments on fleet, commercialization, and cross-platform routes; ID guards on all proxy routes; blocks path-smuggling while accepting RustDesk peer IDs.
+- **Go API SSRF guard** â€” `goApiPath` validates all relative paths on `betterdeskApi` axios client; policy routes validate org/device IDs; help-request IDs validated before proxying.
+- **XSS** â€” `cross-platform.js`, `users.js`, `dataguard.js`, `cdap-studio.js` escape/sanitize dynamic HTML and CSS class names.
+- **Path confinement (CodeQL)** â€” shared `safePath` helper for backup deletion, i18n language files, server file browser, `fontService`, and `fileTransferService` (symlink-aware root checks).
+- **SSRF / shell hardening** â€” OIDC discovery URLs validated before fetch; network monitor HTTP/TCP checks use validated components; terminal proxy restricted to known shell paths; `updateService` and deploy helpers use `execFileSync` argv arrays; `linux-ensure-console-user.js` uses `execFileSync`.
+- **Clear-text logging** â€” admin password no longer logged on first install; API login logs redact usernames (`logRedact.js`); admin self-test password cleared after use.
+- **Audit log** â€” `Recent` / `RecentByAction` clamp `n` to 500 to limit allocation (CodeQL).
+- **CI** â€” `build.yml` default `permissions: contents: read`; write only on release/binary-update jobs.
 
 ### Changed
-- **i18n dev toolkit** moved to `web-nodejs/scripts/dev-i18n/` — not deployed to production; one-shot `patch-*` scripts removed (recoverable from git history).
-- **i18n** — Docker update UI strings and update-channel labels translated across all 26 locales.
+- **i18n dev toolkit** moved to `web-nodejs/scripts/dev-i18n/` â€” not deployed to production; one-shot `patch-*` scripts removed (recoverable from git history).
+- **i18n** â€” Docker update UI strings and update-channel labels translated across all 26 locales.
 
 ---
 
-## [3.1.12] — 2026-06-09
+## [3.1.12] â€” 2026-06-09
 
 ### Fixed
-- **RBAC** — block deleting last `super_admin`; org owner label as Org Admin in all locales.
+- **RBAC** â€” block deleting last `super_admin`; org owner label as Org Admin in all locales.
 
 ---
 
-## [3.1.11] — 2026-06-09
+## [3.1.11] â€” 2026-06-09
 
 ### Security
-- **Go API proxy hardening (phase E)** — shared `goApiProxy.js` validates path segments on fleet, commercialization, and cross-platform routes; blocks path-smuggling while accepting RustDesk peer IDs (numeric and `a-zA-Z0-9_-`).
-- **Help-request API** — `betterdeskApi` validates registration help IDs before proxying to Go.
-- **XSS** — `cross-platform.js`, `users.js`, `dataguard.js`, `cdap-studio.js` escape/sanitize dynamic HTML and CSS class names.
-- **Audit log** — `Recent` / `RecentByAction` clamp `n` to 500 to limit allocation (CodeQL).
-- **Clear-text logging** — admin self-test password cleared after use in `authService`.
+- **Go API proxy hardening (phase E)** â€” shared `goApiProxy.js` validates path segments on fleet, commercialization, and cross-platform routes; blocks path-smuggling while accepting RustDesk peer IDs (numeric and `a-zA-Z0-9_-`).
+- **Help-request API** â€” `betterdeskApi` validates registration help IDs before proxying to Go.
+- **XSS** â€” `cross-platform.js`, `users.js`, `dataguard.js`, `cdap-studio.js` escape/sanitize dynamic HTML and CSS class names.
+- **Audit log** â€” `Recent` / `RecentByAction` clamp `n` to 500 to limit allocation (CodeQL).
+- **Clear-text logging** â€” admin self-test password cleared after use in `authService`.
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.1.10] — 2026-06-09
+## [3.1.10] â€” 2026-06-09
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.1.9] — 2026-06-09
+## [3.1.9] â€” 2026-06-09
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.1.8] — 2026-06-09
+## [3.1.8] â€” 2026-06-09
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.1.7] — 2026-06-09
+## [3.1.7] â€” 2026-06-09
 
 ### Security
-- **Go API SSRF guard** — `goApiPath` validates all relative paths on `betterdeskApi` axios client; policy routes validate org/device IDs.
-- **File browser** — directory listing uses `resolveChildPath` for each entry under an already-confined parent path.
-- **Clear-text logging** — admin password no longer logged on first install; API login logs redacted usernames (`logRedact.js`).
-- **Path confinement** — `fontService` and `fileTransferService` use `safePath.resolveChildPath` for filesystem operations.
-- **CI** — `build.yml` default `permissions: contents: read`; write only on release/binary-update jobs.
+- **Go API SSRF guard** â€” `goApiPath` validates all relative paths on `betterdeskApi` axios client; policy routes validate org/device IDs.
+- **File browser** â€” directory listing uses `resolveChildPath` for each entry under an already-confined parent path.
+- **Clear-text logging** â€” admin password no longer logged on first install; API login logs redacted usernames (`logRedact.js`).
+- **Path confinement** â€” `fontService` and `fileTransferService` use `safePath.resolveChildPath` for filesystem operations.
+- **CI** â€” `build.yml` default `permissions: contents: read`; write only on release/binary-update jobs.
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.1.6] — 2026-06-09
+## [3.1.6] â€” 2026-06-09
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.1.5] — 2026-06-09
+## [3.1.5] â€” 2026-06-09
 
 ### Fixed
-- **Panel update (dev channel)** — after intentional removal of dev-only i18n scripts, the repair step no longer tries to re-download deleted `web-nodejs/scripts/*` paths (404 false failures).
+- **Panel update (dev channel)** â€” after intentional removal of dev-only i18n scripts, the repair step no longer tries to re-download deleted `web-nodejs/scripts/*` paths (404 false failures).
 
 ### Security
-- **Path confinement (CodeQL)** — shared `safePath` helper for backup deletion, i18n language files, and server file browser (symlink-aware root checks).
-- **i18n dev toolkit** moved to `web-nodejs/scripts/dev-i18n/` (`apply-i18n-audit`, `i18n-audit-data/`, `collect-gap-keys`, `generate-gap-fill`) — not deployed to production; one-shot feature `patch-*` scripts removed (recoverable from git history).
-- **SSRF hardening** — network monitor HTTP checks use `http.request` with validated hostname/port/path components.
-- **Terminal proxy** — login shells restricted to known system shell paths.
-- **Installer scripts** — `linux-ensure-console-user.js` uses `execFileSync` argv arrays instead of shell strings.
-- **OIDC discovery** — HTTP fetch uses validated URL string after SSRF checks.
+- **Path confinement (CodeQL)** â€” shared `safePath` helper for backup deletion, i18n language files, and server file browser (symlink-aware root checks).
+- **i18n dev toolkit** moved to `web-nodejs/scripts/dev-i18n/` (`apply-i18n-audit`, `i18n-audit-data/`, `collect-gap-keys`, `generate-gap-fill`) â€” not deployed to production; one-shot feature `patch-*` scripts removed (recoverable from git history).
+- **SSRF hardening** â€” network monitor HTTP checks use `http.request` with validated hostname/port/path components.
+- **Terminal proxy** â€” login shells restricted to known system shell paths.
+- **Installer scripts** â€” `linux-ensure-console-user.js` uses `execFileSync` argv arrays instead of shell strings.
+- **OIDC discovery** â€” HTTP fetch uses validated URL string after SSRF checks.
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.1.4] — 2026-06-09
+## [3.1.4] â€” 2026-06-09
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.1.3] — 2026-06-09
+## [3.1.3] â€” 2026-06-09
 
 ### Security
-- **CVE-2026-50575 / GHSA-3v82-3gf8-fxx8 (device replay after delete)** — WebSocket signal registration now rejects soft-deleted peer IDs (new registration and heartbeat), matching the existing UDP/TCP path. `UpdatePeerStatus` no longer marks soft-deleted rows `ONLINE`. Restoration remains explicit via `POST /api/peers/{id}/restore` only. Ships via panel update (`betterdesk-server`).
-- **Dependency updates (Dependabot)** — `go-ntlmssp` 0.1.1 (CVE-2026-32952), `golang.org/x/image` 0.38.0 (CVE-2026-33809), `pgx/v5` 5.9.2 in Go modules; `openssl` 0.10.80 and `tauri` 2.11.2 in Tauri `Cargo.lock` files (desktop client rebuild required for Rust-side fixes).
-- **SSRF / path hardening (CodeQL)** — OIDC discovery URLs validated before fetch; language file routes confined to `lang/`; server file browser paths restricted to allowed roots (`BETTERDESK_FILE_ALLOWED_ROOTS`); network monitor TCP checks resolve DNS before connect; address-book tag merge capped to prevent allocation overflow.
-- **Shell / logging hardening** — `updateService` and deploy helpers use `execFileSync` argv arrays; auth audit logs no longer echo operator usernames on sensitive paths; system log/stats routes rate-limited.
+- **CVE-2026-50575 / GHSA-3v82-3gf8-fxx8 (device replay after delete)** â€” WebSocket signal registration now rejects soft-deleted peer IDs (new registration and heartbeat), matching the existing UDP/TCP path. `UpdatePeerStatus` no longer marks soft-deleted rows `ONLINE`. Restoration remains explicit via `POST /api/peers/{id}/restore` only. Ships via panel update (`betterdesk-server`).
+- **Dependency updates (Dependabot)** â€” `go-ntlmssp` 0.1.1 (CVE-2026-32952), `golang.org/x/image` 0.38.0 (CVE-2026-33809), `pgx/v5` 5.9.2 in Go modules; `openssl` 0.10.80 and `tauri` 2.11.2 in Tauri `Cargo.lock` files (desktop client rebuild required for Rust-side fixes).
+- **SSRF / path hardening (CodeQL)** â€” OIDC discovery URLs validated before fetch; language file routes confined to `lang/`; server file browser paths restricted to allowed roots (`BETTERDESK_FILE_ALLOWED_ROOTS`); network monitor TCP checks resolve DNS before connect; address-book tag merge capped to prevent allocation overflow.
+- **Shell / logging hardening** â€” `updateService` and deploy helpers use `execFileSync` argv arrays; auth audit logs no longer echo operator usernames on sensitive paths; system log/stats routes rate-limited.
 
 ---
 
-## [3.1.2] — 2026-06-08
+## [3.1.2] â€” 2026-06-08
 
 ### Added
-- **One-line Linux installer (`install.sh`)** — `curl -fsSL …/install.sh | sudo bash` performs a fully automated Docker quick-start (Docker engine install when missing, compose download with validation, relay IP detection, firewall rules, health wait, credential summary). Use `--native` for git clone + `betterdesk.sh --auto`, or `--uninstall` / `--purge` to tear down the Docker stack.
+- **One-line Linux installer (`install.sh`)** â€” `curl -fsSL â€¦/install.sh | sudo bash` performs a fully automated Docker quick-start (Docker engine install when missing, compose download with validation, relay IP detection, firewall rules, health wait, credential summary). Use `--native` for git clone + `betterdesk.sh --auto`, or `--uninstall` / `--purge` to tear down the Docker stack.
 
 ---
 
-## [3.1.1] — 2026-06-08
+## [3.1.1] â€” 2026-06-08
 
 ### Changed
 - _(none yet)_
 
 ---
 
-## [3.1.0] — 2026-06-07
+## [3.1.0] â€” 2026-06-07
 
 ### Changed
 - _(none yet)_
@@ -2355,159 +2358,159 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
-## [3.0.1] — 2026-06-07 — Security hardening (2026-04-26)
+## [3.0.1] â€” 2026-06-07 â€” Security hardening (2026-04-26)
 
 ### Added
-- **Czech console translation completed** — `web-nodejs/lang/cs.json` now contains Czech UI text instead of the previous English fallback content and has the correct `meta.lang` value. Community contribution by [Karel Lowprize K](https://github.com/lowprize) ([PR #133](https://github.com/UNITRONIX/BetterDesk/pull/133)).
-- **RustDesk PRO group endpoint stubs** — `betterdesk-server/api/server.go` now exposes `GET /api/group`, `GET|POST /api/group/get`, and `GET /api/peers/list` returning the `{total, data, msg}` envelope expected by RustDesk Flutter clients. Without these endpoints the Flutter UI aborted device-list loading and never fell back to address-book mode. Idea credit: [progloto](https://github.com/progloto) ([PR #81](https://github.com/UNITRONIX/BetterDesk/pull/81)).
-- **Catch-all 404 logging** — Both `betterdesk-server/api/server.go` (Go API) and `web-nodejs/server.js` (RustDesk-compatible API + main panel) now log unmatched routes with method, path, client IP, and User-Agent. Makes missing client-compatibility endpoints easy to spot during deployments. Diagnostics suggestion credit: [progloto](https://github.com/progloto) ([PR #81](https://github.com/UNITRONIX/BetterDesk/pull/81)).
-- **Defensive list parsing in panel** — `web-nodejs/services/betterdeskApi.js` and `web-nodejs/public/js/devices.js` already accepted both `[…]` and `{ peers: […] }` shapes; this stays unchanged so admin UI works regardless of which endpoint envelope a future RustDesk version returns.
+- **Czech console translation completed** â€” `web-nodejs/lang/cs.json` now contains Czech UI text instead of the previous English fallback content and has the correct `meta.lang` value. Community contribution by [Karel Lowprize K](https://github.com/lowprize) ([PR #133](https://github.com/UNITRONIX/BetterDesk/pull/133)).
+- **RustDesk PRO group endpoint stubs** â€” `betterdesk-server/api/server.go` now exposes `GET /api/group`, `GET|POST /api/group/get`, and `GET /api/peers/list` returning the `{total, data, msg}` envelope expected by RustDesk Flutter clients. Without these endpoints the Flutter UI aborted device-list loading and never fell back to address-book mode. Idea credit: [progloto](https://github.com/progloto) ([PR #81](https://github.com/UNITRONIX/BetterDesk/pull/81)).
+- **Catch-all 404 logging** â€” Both `betterdesk-server/api/server.go` (Go API) and `web-nodejs/server.js` (RustDesk-compatible API + main panel) now log unmatched routes with method, path, client IP, and User-Agent. Makes missing client-compatibility endpoints easy to spot during deployments. Diagnostics suggestion credit: [progloto](https://github.com/progloto) ([PR #81](https://github.com/UNITRONIX/BetterDesk/pull/81)).
+- **Defensive list parsing in panel** â€” `web-nodejs/services/betterdeskApi.js` and `web-nodejs/public/js/devices.js` already accepted both `[â€¦]` and `{ peers: [â€¦] }` shapes; this stays unchanged so admin UI works regardless of which endpoint envelope a future RustDesk version returns.
 
 ### Changed
-- **Docker quick-start admin credential lookup** — README and `docker-compose.quick.yml` now point users to the secure `.admin_credentials` file shared with the console container instead of grepping logs that do not reliably contain the generated password. Documentation suggestion by [Karel Lowprize K](https://github.com/lowprize) ([PR #134](https://github.com/UNITRONIX/BetterDesk/pull/134)).
+- **Docker quick-start admin credential lookup** â€” README and `docker-compose.quick.yml` now point users to the secure `.admin_credentials` file shared with the console container instead of grepping logs that do not reliably contain the generated password. Documentation suggestion by [Karel Lowprize K](https://github.com/lowprize) ([PR #134](https://github.com/UNITRONIX/BetterDesk/pull/134)).
 
 ### Fixed
-- **Live device-status updates on the Devices page** — The WebSocket status handler now updates the current device state array and visible status badge without referencing a stale `allDevices` variable. This was found while reviewing Rafael Monteiro's heartbeat/status contribution ([PR #35](https://github.com/UNITRONIX/BetterDesk/pull/35)).
-- **RustDesk WSS rendezvous timeout behind reverse proxies** — The Go signal WebSocket endpoint now sends RustDesk-compatible empty binary keepalive frames and ignores empty keepalive replies from clients. This prevents `Rendezvous connection is timeout` after a successful WSS handshake when Nginx proxies `/ws/id` to port `21118`. Reported by [odixz](https://github.com/odixz) ([#144](https://github.com/UNITRONIX/BetterDesk/issues/144)).
-- **RustDesk WSS peer cleanup after keepalive** — Empty RustDesk WebSocket keepalive replies now refresh the in-memory peer heartbeat, preventing the signal server from marking an active WSS peer offline after the 30-second cleanup window. Follow-up logs and retest by [odixz](https://github.com/odixz) ([#144](https://github.com/UNITRONIX/BetterDesk/issues/144)).
+- **Live device-status updates on the Devices page** â€” The WebSocket status handler now updates the current device state array and visible status badge without referencing a stale `allDevices` variable. This was found while reviewing Rafael Monteiro's heartbeat/status contribution ([PR #35](https://github.com/UNITRONIX/BetterDesk/pull/35)).
+- **RustDesk WSS rendezvous timeout behind reverse proxies** â€” The Go signal WebSocket endpoint now sends RustDesk-compatible empty binary keepalive frames and ignores empty keepalive replies from clients. This prevents `Rendezvous connection is timeout` after a successful WSS handshake when Nginx proxies `/ws/id` to port `21118`. Reported by [odixz](https://github.com/odixz) ([#144](https://github.com/UNITRONIX/BetterDesk/issues/144)).
+- **RustDesk WSS peer cleanup after keepalive** â€” Empty RustDesk WebSocket keepalive replies now refresh the in-memory peer heartbeat, preventing the signal server from marking an active WSS peer offline after the 30-second cleanup window. Follow-up logs and retest by [odixz](https://github.com/odixz) ([#144](https://github.com/UNITRONIX/BetterDesk/issues/144)).
 
 ### Security
-- **Brute-force protection on RustDesk client API** — `web-nodejs/routes/rustdesk-api.routes.js` now `await`s `authService.checkBruteForce(...)`. Previously the async result was treated as truthy/undefined, making the lockout effectively unenforceable on the RustDesk-compatible login route. (Audit finding #1, High)
-- **TOTP login session fixation** — `web-nodejs/routes/auth.routes.js` regenerates the session via `req.session.regenerate(...)` after successful 2FA verification, mirroring the standard login flow. Previously the pre-2FA session ID was reused for the post-2FA authenticated session. Cookie name is unchanged; existing browser sessions continue to work. (Audit finding #2, Medium)
-- **Audit endpoints now require explicit RBAC** — `betterdesk-server/api/server.go` wraps `GET /api/audit/events` and `GET /api/ws/events` in `requirePermission(auth.PermAuditView, ...)`. All built-in roles that previously consumed these endpoints (`super_admin`, `admin`, `server_admin`, `global_admin`, `operator`, `viewer`) already grant `audit.view` by default — no behavioural change for them. **Behavioural change:** the `pro` role no longer receives `200` from these endpoints (it never had `audit.view` in `DefaultRolePermissions`). If a deployment relied on this implicit access, grant `audit.view` explicitly via the role-permission overrides table. (Audit finding #3, Medium)
-- **Generic 500 responses from Go auth handlers** — `betterdesk-server/api/auth_handlers.go` no longer leaks `err.Error()` strings on 9 internal-server-error paths (list/update/delete users, TOTP setup/confirm/disable, list/create/delete API keys). Full error detail is now logged server-side via `log.Printf`. Status codes and non-500 responses are unchanged. (Audit finding #4, Medium)
+- **Brute-force protection on RustDesk client API** â€” `web-nodejs/routes/rustdesk-api.routes.js` now `await`s `authService.checkBruteForce(...)`. Previously the async result was treated as truthy/undefined, making the lockout effectively unenforceable on the RustDesk-compatible login route. (Audit finding #1, High)
+- **TOTP login session fixation** â€” `web-nodejs/routes/auth.routes.js` regenerates the session via `req.session.regenerate(...)` after successful 2FA verification, mirroring the standard login flow. Previously the pre-2FA session ID was reused for the post-2FA authenticated session. Cookie name is unchanged; existing browser sessions continue to work. (Audit finding #2, Medium)
+- **Audit endpoints now require explicit RBAC** â€” `betterdesk-server/api/server.go` wraps `GET /api/audit/events` and `GET /api/ws/events` in `requirePermission(auth.PermAuditView, ...)`. All built-in roles that previously consumed these endpoints (`super_admin`, `admin`, `server_admin`, `global_admin`, `operator`, `viewer`) already grant `audit.view` by default â€” no behavioural change for them. **Behavioural change:** the `pro` role no longer receives `200` from these endpoints (it never had `audit.view` in `DefaultRolePermissions`). If a deployment relied on this implicit access, grant `audit.view` explicitly via the role-permission overrides table. (Audit finding #3, Medium)
+- **Generic 500 responses from Go auth handlers** â€” `betterdesk-server/api/auth_handlers.go` no longer leaks `err.Error()` strings on 9 internal-server-error paths (list/update/delete users, TOTP setup/confirm/disable, list/create/delete API keys). Full error detail is now logged server-side via `log.Printf`. Status codes and non-500 responses are unchanged. (Audit finding #4, Medium)
 
 ### Deferred
 - Plaintext storage of RustDesk client access tokens (audit finding #5) and CSP `'unsafe-inline'`/`'unsafe-eval'` exceptions (audit finding #6) are intentionally **not** included in this batch. They require a phased rollout that would otherwise break existing installations or active client sessions. Tracked in [docs/security/LOGIN_API_SECURITY_AUDIT_2026-04-26.md](docs/security/LOGIN_API_SECURITY_AUDIT_2026-04-26.md#deferred-patches).
 
 ---
 
-## [3.0.0] — 2026-06-07
+## [3.0.0] â€” 2026-06-07
 
 ### Fixed
-- **SQLite auth.db upgrade crash (issue #158)** — Console startup no longer fails with `SqliteError: no such column: token_hash` on existing `auth.db` volumes. The `token_hash` column and index are now added before any index DDL runs; legacy access tokens are backfilled with SHA-256 hashes on first boot.
-- **Docker image version display** — Container entrypoints and image labels now report **3.0.0** (via `BETTERDESK_IMAGE_VERSION` at build time).
+- **SQLite auth.db upgrade crash (issue #158)** â€” Console startup no longer fails with `SqliteError: no such column: token_hash` on existing `auth.db` volumes. The `token_hash` column and index are now added before any index DDL runs; legacy access tokens are backfilled with SHA-256 hashes on first boot.
+- **Docker image version display** â€” Container entrypoints and image labels now report **3.0.0** (via `BETTERDESK_IMAGE_VERSION` at build time).
 
 ### Changed
-- **Docker quick-start default image tag** — `docker-compose.quick.yml` pins `ghcr.io/unitronix/betterdesk-{server,console}:3.0.0` instead of `3.0.0-alpha`.
+- **Docker quick-start default image tag** â€” `docker-compose.quick.yml` pins `ghcr.io/unitronix/betterdesk-{server,console}:3.0.0` instead of `3.0.0-alpha`.
 
 ---
 
-## [3.0.0-alpha] — 2026-04-01
+## [3.0.0-alpha] â€” 2026-04-01
 
 ### Added
-- **Organization & User Account System** — Multi-tenant organizations with owner/admin/operator/user roles (Go server + Node.js panel)
-- **Organization REST API** — 18 endpoints for CRUD orgs, users, devices, invitations, settings, login
-- **Client Organization Login** — `OrgLoginPanel.tsx` with server address + username/password
-- **mDNS/DNS-SD Discovery** — Auto-discover BetterDesk servers on LAN (`_betterdesk._tcp`)
-- **Desktop Widget UI Overhaul** — New window management, taskbar redesign, wallpaper picker with tabs
-- **Chat 2.0** — Operator↔device group chat, E2E encryption (ECDH + AES-256-GCM), read receipts, file sharing, typing indicators
-- **Web Remote File Transfer** — Browser-based bidirectional file transfer with drag-and-drop, progress tracking, resume, history
-- **Security Hardening** — Organization-scoped policies (password, session, IP whitelist, device enrollment, 2FA, data retention)
-- **Fleet Management** — Device groups with tags, batch operations (restart, update, lock, wipe), cascading deletion
-- **Scaling Infrastructure** — Load balancer health checks, horizontal scaling config, region-aware relay selection
-- **Cross-Platform Support** — Platform detection, feature matrix, capabilities API per OS/browser
-- **Security Audit Module** — Built-in scanner with 8 check categories, compliance scoring, scheduled scans, PDF/JSON/CSV reports
-- **i18n Expansion** — 25+ languages (auto-discovery), Language Management admin page, `i18n:check` script with `--fix` mode
-- **Device Resource Control** — USB, optical drive, monitor, disk, quota policy management per device
-- **CDAP Documentation** — Protocol spec, agent guide, bridge guide, API reference (5 docs)
-- **SDK Documentation** — Python + Node.js SDK reference, integration examples, studio guide (5 docs)
-- **Pre-Release Checklist** — 8-section validation checklist for releases
-- **Docker SBOM + Trivy** — SBOM generation and vulnerability scanning in CI
-- **6 New Console Languages** — German, Spanish, French, Italian, Dutch, Portuguese
-- **3 High-Priority Languages** — Japanese, Korean, Chinese (Simplified)
-- **12 Additional Languages** — Arabic, Hebrew, Ukrainian, Turkish, Hindi, Swedish, Norwegian, Danish, Finnish, Czech, Hungarian, Romanian, Thai, Vietnamese, Indonesian
-- **Desktop Client i18n Framework** — `src/lib/i18n.ts` with `t()` function, plural forms, locale detection
-- **NSIS Multilingual Installer** — 12 languages in NSIS language selector
-- **Light Theme** — `themes/light.json` with WCAG-compliant light colors
-- **Theme API** — `GET /api/settings/themes`, `POST /api/settings/themes/:id/apply`
-- **Page Transition Animations** — `transitions.css` with page enter/exit, stagger, skeleton loading
-- **GitHub Actions: Client Releases** — Multi-platform Tauri builds (Windows/Linux/macOS)
-- **GitHub Actions: Server Releases** — Go cross-compile (linux-amd64/arm64, windows-amd64)
-- **Security Documentation** — THREAT_MODEL.md, ENCRYPTION_SPEC.md, COMPLIANCE.md, AUDIT_LOG.md
-- **Responsible Disclosure Policy** — `.github/SECURITY.md`
-- **Web Remote Toolbar** — Scale mode selector, monitor switcher, clipboard sync, special keys menu
-- **Fullscreen Mode** — F11 keyboard shortcut + button toggle
-- **Bidirectional Clipboard** — `navigator.clipboard` API integration in remote viewer
-- **Special Keys Menu** — Ctrl+Alt+Del, Win, PrintScreen, Alt+Tab, Alt+F4, Task Manager
-- **Beta Banner** — Replaced WIP banner with slim dismissible beta indicator
+- **Organization & User Account System** â€” Multi-tenant organizations with owner/admin/operator/user roles (Go server + Node.js panel)
+- **Organization REST API** â€” 18 endpoints for CRUD orgs, users, devices, invitations, settings, login
+- **Client Organization Login** â€” `OrgLoginPanel.tsx` with server address + username/password
+- **mDNS/DNS-SD Discovery** â€” Auto-discover BetterDesk servers on LAN (`_betterdesk._tcp`)
+- **Desktop Widget UI Overhaul** â€” New window management, taskbar redesign, wallpaper picker with tabs
+- **Chat 2.0** â€” Operatorâ†”device group chat, E2E encryption (ECDH + AES-256-GCM), read receipts, file sharing, typing indicators
+- **Web Remote File Transfer** â€” Browser-based bidirectional file transfer with drag-and-drop, progress tracking, resume, history
+- **Security Hardening** â€” Organization-scoped policies (password, session, IP whitelist, device enrollment, 2FA, data retention)
+- **Fleet Management** â€” Device groups with tags, batch operations (restart, update, lock, wipe), cascading deletion
+- **Scaling Infrastructure** â€” Load balancer health checks, horizontal scaling config, region-aware relay selection
+- **Cross-Platform Support** â€” Platform detection, feature matrix, capabilities API per OS/browser
+- **Security Audit Module** â€” Built-in scanner with 8 check categories, compliance scoring, scheduled scans, PDF/JSON/CSV reports
+- **i18n Expansion** â€” 25+ languages (auto-discovery), Language Management admin page, `i18n:check` script with `--fix` mode
+- **Device Resource Control** â€” USB, optical drive, monitor, disk, quota policy management per device
+- **CDAP Documentation** â€” Protocol spec, agent guide, bridge guide, API reference (5 docs)
+- **SDK Documentation** â€” Python + Node.js SDK reference, integration examples, studio guide (5 docs)
+- **Pre-Release Checklist** â€” 8-section validation checklist for releases
+- **Docker SBOM + Trivy** â€” SBOM generation and vulnerability scanning in CI
+- **6 New Console Languages** â€” German, Spanish, French, Italian, Dutch, Portuguese
+- **3 High-Priority Languages** â€” Japanese, Korean, Chinese (Simplified)
+- **12 Additional Languages** â€” Arabic, Hebrew, Ukrainian, Turkish, Hindi, Swedish, Norwegian, Danish, Finnish, Czech, Hungarian, Romanian, Thai, Vietnamese, Indonesian
+- **Desktop Client i18n Framework** â€” `src/lib/i18n.ts` with `t()` function, plural forms, locale detection
+- **NSIS Multilingual Installer** â€” 12 languages in NSIS language selector
+- **Light Theme** â€” `themes/light.json` with WCAG-compliant light colors
+- **Theme API** â€” `GET /api/settings/themes`, `POST /api/settings/themes/:id/apply`
+- **Page Transition Animations** â€” `transitions.css` with page enter/exit, stagger, skeleton loading
+- **GitHub Actions: Client Releases** â€” Multi-platform Tauri builds (Windows/Linux/macOS)
+- **GitHub Actions: Server Releases** â€” Go cross-compile (linux-amd64/arm64, windows-amd64)
+- **Security Documentation** â€” THREAT_MODEL.md, ENCRYPTION_SPEC.md, COMPLIANCE.md, AUDIT_LOG.md
+- **Responsible Disclosure Policy** â€” `.github/SECURITY.md`
+- **Web Remote Toolbar** â€” Scale mode selector, monitor switcher, clipboard sync, special keys menu
+- **Fullscreen Mode** â€” F11 keyboard shortcut + button toggle
+- **Bidirectional Clipboard** â€” `navigator.clipboard` API integration in remote viewer
+- **Special Keys Menu** â€” Ctrl+Alt+Del, Win, PrintScreen, Alt+Tab, Alt+F4, Task Manager
+- **Beta Banner** â€” Replaced WIP banner with slim dismissible beta indicator
 
 ### Changed
-- **CSP Headers Hardened** — Added `frame-ancestors`, `worker-src`, `child-src`; expanded Permissions-Policy
-- **X-Frame-Options** — Changed from `DENY` to `SAMEORIGIN` for desktop widget embed mode
-- **WebSocket CSP** — Added `ws:` to `connect-src` for HTTP mode (was missing)
-- **Cross-Origin Resource Policy** — Enabled `same-origin` (was disabled)
+- **CSP Headers Hardened** â€” Added `frame-ancestors`, `worker-src`, `child-src`; expanded Permissions-Policy
+- **X-Frame-Options** â€” Changed from `DENY` to `SAMEORIGIN` for desktop widget embed mode
+- **WebSocket CSP** â€” Added `ws:` to `connect-src` for HTTP mode (was missing)
+- **Cross-Origin Resource Policy** â€” Enabled `same-origin` (was disabled)
 
 ### Fixed
-- **Chat: Tray opens wrong window** — Tray "Chat" now opens dedicated chat WebviewWindow directly
-- **Chat: Shows "Disconnected"** — WebSocket URL now uses dynamic `ws://`/`wss://` based on console_url
-- **Rust warnings** — All 10 compilation warnings fixed (unused imports, variables, labels)
-- **Go warnings** — `go vet` clean, 0 issues
+- **Chat: Tray opens wrong window** â€” Tray "Chat" now opens dedicated chat WebviewWindow directly
+- **Chat: Shows "Disconnected"** â€” WebSocket URL now uses dynamic `ws://`/`wss://` based on console_url
+- **Rust warnings** â€” All 10 compilation warnings fixed (unused imports, variables, labels)
+- **Go warnings** â€” `go vet` clean, 0 issues
 
 ---
 
-## [2.4.0] — 2026-03-21
+## [2.4.0] â€” 2026-03-21
 
 ### Added
-- **PostgreSQL Support** — Full PostgreSQL database backend for Go server and Node.js console
-- **SQLite → PostgreSQL Migration** — Built-in migration tool (menu option M/P)
-- **CDAP v0.3.0** — Widget rendering, device detail page, REST API, 8 widget types
-- **Native BetterDesk Agent** — Go binary for system management, 14 flags, 9 widgets
-- **Bridge SDK** — Python + Node.js SDKs for CDAP bridges (Modbus, SNMP, REST)
-- **Device Revocation** — `DELETE /api/peers/{id}?revoke=true&cascade=true`
-- **Peer Metrics** — `peer_metrics` table, `GET /api/peers/{id}/metrics`
-- **CDAP Audio** — Bidirectional audio streaming via WebSocket
-- **Devices Page Redesign** — Horizontal folder chips, kebab menu, responsive layout
-- **Docker GHCR** — Pre-built images on GitHub Container Registry
+- **PostgreSQL Support** â€” Full PostgreSQL database backend for Go server and Node.js console
+- **SQLite â†’ PostgreSQL Migration** â€” Built-in migration tool (menu option M/P)
+- **CDAP v0.3.0** â€” Widget rendering, device detail page, REST API, 8 widget types
+- **Native BetterDesk Agent** â€” Go binary for system management, 14 flags, 9 widgets
+- **Bridge SDK** â€” Python + Node.js SDKs for CDAP bridges (Modbus, SNMP, REST)
+- **Device Revocation** â€” `DELETE /api/peers/{id}?revoke=true&cascade=true`
+- **Peer Metrics** â€” `peer_metrics` table, `GET /api/peers/{id}/metrics`
+- **CDAP Audio** â€” Bidirectional audio streaming via WebSocket
+- **Devices Page Redesign** â€” Horizontal folder chips, kebab menu, responsive layout
+- **Docker GHCR** â€” Pre-built images on GitHub Container Registry
 
 ### Fixed
-- **Empty UUID in Relay** — Generate UUID when `RequestRelay{uuid=""}` received
-- **ForceRelay TCP UUID Mismatch** — Return `PunchHoleResponse` instead of `RelayResponse`
-- **Docker Port 5000 Conflict** — Added `SIGNAL_PORT` env var, priority over `PORT`
-- **PS1 RandomNumberGenerator Crash** — Replaced .NET 6+ method with .NET 4.x compatible
-- **API TLS Breaking Clients** — Separated `--tls-api` flag from signal/relay TLS
-- **PostgreSQL Config Lost on Update** — Added `preserve_database_config()` function
-- **Auth.db Destroyed on Update** — Detect existing `.env` as UPDATE indicator
-- **Address Book Sync** — Real `address_books` table replacing stub handlers
-- **Settings Password** — Fixed snake_case vs camelCase field name mismatch
+- **Empty UUID in Relay** â€” Generate UUID when `RequestRelay{uuid=""}` received
+- **ForceRelay TCP UUID Mismatch** â€” Return `PunchHoleResponse` instead of `RelayResponse`
+- **Docker Port 5000 Conflict** â€” Added `SIGNAL_PORT` env var, priority over `PORT`
+- **PS1 RandomNumberGenerator Crash** â€” Replaced .NET 6+ method with .NET 4.x compatible
+- **API TLS Breaking Clients** â€” Separated `--tls-api` flag from signal/relay TLS
+- **PostgreSQL Config Lost on Update** â€” Added `preserve_database_config()` function
+- **Auth.db Destroyed on Update** â€” Detect existing `.env` as UPDATE indicator
+- **Address Book Sync** â€” Real `address_books` table replacing stub handlers
+- **Settings Password** â€” Fixed snake_case vs camelCase field name mismatch
 
 ---
 
-## [2.3.0] — 2026-02-17
+## [2.3.0] â€” 2026-02-17
 
 ### Added
-- **CSRF Protection** — Double-submit cookie pattern with `csrf-csrf`
-- **TOTP 2FA** — Two-factor authentication with `otplib`
-- **RustDesk Client API** — Dedicated WAN-facing port 21121 with 7-layer security
-- **Address Book Sync** — Full AB storage with `address_books` table
-- **Operator Role** — Admin/operator role separation with different permissions
-- **SSL Certificate Configuration** — New menu option C in installer scripts
-- **Desktop Connect Button** — Connect to devices from browser via RustDesk URI handler
+- **CSRF Protection** â€” Double-submit cookie pattern with `csrf-csrf`
+- **TOTP 2FA** â€” Two-factor authentication with `otplib`
+- **RustDesk Client API** â€” Dedicated WAN-facing port 21121 with 7-layer security
+- **Address Book Sync** â€” Full AB storage with `address_books` table
+- **Operator Role** â€” Admin/operator role separation with different permissions
+- **SSL Certificate Configuration** â€” New menu option C in installer scripts
+- **Desktop Connect Button** â€” Connect to devices from browser via RustDesk URI handler
 
 ### Fixed
-- **Session Fixation** — Session regeneration after login
-- **Timing-Safe Auth** — Pre-computed dummy bcrypt hash for non-existent users
-- **WebSocket Auth** — Session cookie required for upgrade
-- **Web Remote Client** — 5 Critical, 2 High, 3 Low bugs fixed
+- **Session Fixation** â€” Session regeneration after login
+- **Timing-Safe Auth** â€” Pre-computed dummy bcrypt hash for non-existent users
+- **WebSocket Auth** â€” Session cookie required for upgrade
+- **Web Remote Client** â€” 5 Critical, 2 High, 3 Low bugs fixed
 
 ---
 
-## [2.2.0] — 2026-02-06
+## [2.2.0] â€” 2026-02-06
 
 ### Added
-- **Node.js Console** — Express.js web console replacing Flask
-- **Migration Tool** — Migrate between console types
-- **Automatic Node.js Installation** — Installer detects and installs Node.js
+- **Node.js Console** â€” Express.js web console replacing Flask
+- **Migration Tool** â€” Migrate between console types
+- **Automatic Node.js Installation** â€” Installer detects and installs Node.js
 
 ---
 
-## [2.1.0] — 2026-02-04
+## [2.1.0] â€” 2026-02-04
 
 ### Added
-- **Go Server** — Single binary replacing hbbs + hbbr (~20K LOC)
-- **ALL-IN-ONE Scripts** — `betterdesk.sh` + `betterdesk.ps1` + `betterdesk-docker.sh`
-- **Automatic Mode** — `--auto` flag for non-interactive installation
-- **SHA256 Verification** — Automatic checksum verification of binaries
+- **Go Server** â€” Single binary replacing hbbs + hbbr (~20K LOC)
+- **ALL-IN-ONE Scripts** â€” `betterdesk.sh` + `betterdesk.ps1` + `betterdesk-docker.sh`
+- **Automatic Mode** â€” `--auto` flag for non-interactive installation
+- **SHA256 Verification** â€” Automatic checksum verification of binaries
 
 ---
 

--- a/rdclient-desktop/src-tauri/src/desktop_clipboard.rs
+++ b/rdclient-desktop/src-tauri/src/desktop_clipboard.rs
@@ -288,16 +288,16 @@ fn file_descriptor_bin(entry: &LocalFileEntry) -> Vec<u8> {
     let name = encode_utf16le_path(&rel_str);
     let name_len = name.len().min(520);
 
-    // Match RustDesk wf_cliprdr outbound flags:
-    //   FD_ATTRIBUTES | FD_WRITESTIME | FD_PROGRESSUI
-    // Deliberately omit FD_FILESIZE. When FD_FILESIZE is set, the remote
-    // CliprdrStream uses nFileSize* as the stream length and never probes
-    // FILECONTENTS_SIZE. A zero (or mistrusted) advertised size becomes
-    // immediate EOF → remote Explorer creates a 0 KB shell with no progress
-    // and no FILECONTENTS_RANGE requests. RustDesk keeps FD_FILESIZE off for
-    // compatibility and lets the peer learn size via FILECONTENTS_SIZE.
-    // Also never set 0x08 as "unix mode" — that bit is Windows FD_CREATETIME.
-    let flags = FLAGS_FD_LAST_WRITE | FLAGS_FD_ATTRIBUTES | FLAGS_FD_PROGRESSUI;
+    // Advertise FD_FILESIZE with a correct FILEDESCRIPTORW layout so remote
+    // Explorer can open the paste menu without a FILECONTENTS_SIZE round-trip
+    // per file (those probes over the desktop relay freeze Explorer as
+    // "Not Responding"). Keep size fields accurate — the #350 0 KB bug was
+    // empty RANGE payloads (base64 coerce) plus mistyped FD_CREATETIME (0x08),
+    // not FD_FILESIZE itself. Never set 0x08 ("unix mode" mistype).
+    let flags = FLAGS_FD_SIZE
+        | FLAGS_FD_LAST_WRITE
+        | FLAGS_FD_ATTRIBUTES
+        | FLAGS_FD_PROGRESSUI;
 
     let mut buf = Vec::with_capacity(FILEDESCRIPTORW_SIZE);
     put_u32_le(&mut buf, flags);
@@ -306,7 +306,6 @@ fn file_descriptor_bin(entry: &LocalFileEntry) -> Vec<u8> {
     // ftCreationTime (8) + ftLastAccessTime (8) — leave zeroed.
     buf.extend_from_slice(&[0u8; 16]);
     put_u64_le(&mut buf, win32_time); // ftLastWriteTime
-    // Still populate size fields (RustDesk does too) even without FD_FILESIZE.
     put_u32_le(&mut buf, size_high);
     put_u32_le(&mut buf, size_low);
     buf.extend_from_slice(&name[..name_len]);
@@ -463,32 +462,77 @@ fn construct_file_list(paths: &[PathBuf]) -> Result<Vec<LocalFileEntry>, String>
     Ok(out)
 }
 
-/// Build FILEGROUPDESCRIPTOR + file_list on demand (Paste / FormatData), not on
-/// every clipboard poll. Copying a large local folder must stay cheap until the
-/// peer actually requests descriptors or file bytes.
-fn ensure_files_materialized(cache: &mut ClipFileCache) -> Result<(), String> {
-    if cache.too_large {
-        return Err("cliprdr_too_large".into());
-    }
-    if !cache.files_pdu.is_empty() && !cache.file_list.is_empty() {
-        return Ok(());
-    }
-    if cache.top_paths.is_empty() {
-        return Err("no clipboard files cached".into());
-    }
-    let path_bufs: Vec<PathBuf> = cache.top_paths.iter().map(PathBuf::from).collect();
-    match construct_file_list(&path_bufs) {
-        Ok(list) => {
-            cache.entry_count = list.len() as u32;
-            cache.total_bytes = list.iter().filter(|e| !e.is_dir).map(|e| e.size).sum();
-            cache.file_list = list;
-            cache.files_pdu = build_files_pdu(&cache.file_list);
+/// Build FILEGROUPDESCRIPTOR + file_list for `paths` (no cache lock held).
+fn materialize_paths(
+    paths: &[PathBuf],
+) -> Result<(Vec<LocalFileEntry>, Vec<u8>, u32, u64), String> {
+    let list = construct_file_list(paths)?;
+    let total_bytes = list.iter().filter(|e| !e.is_dir).map(|e| e.size).sum();
+    let entry_count = list.len() as u32;
+    let pdu = build_files_pdu(&list);
+    Ok((list, pdu, entry_count, total_bytes))
+}
+
+fn apply_too_large(cache: &mut ClipFileCache, entries: u32, bytes: u64) {
+    cache.too_large = true;
+    cache.entry_count = entries;
+    cache.total_bytes = bytes;
+    cache.file_list.clear();
+    cache.files_pdu.clear();
+}
+
+fn apply_materialized(
+    cache: &mut ClipFileCache,
+    list: Vec<LocalFileEntry>,
+    pdu: Vec<u8>,
+    entry_count: u32,
+    total_bytes: u64,
+) {
+    cache.too_large = false;
+    cache.entry_count = entry_count;
+    cache.total_bytes = total_bytes;
+    cache.file_list = list;
+    cache.files_pdu = pdu;
+}
+
+/// Ensure PDU/file_list exist without holding CLIP_CACHE across disk walks.
+/// Remote Explorer context menus request FormatData on right-click — a locked
+/// tree walk here freezes the remote for tens of seconds.
+fn ensure_files_ready() -> Result<(), String> {
+    let (paths, signature) = {
+        let cache = CLIP_CACHE
+            .lock()
+            .map_err(|_| "Clipboard cache lock poisoned".to_string())?;
+        if cache.too_large {
+            return Err("cliprdr_too_large".into());
+        }
+        if !cache.files_pdu.is_empty() && !cache.file_list.is_empty() {
+            return Ok(());
+        }
+        if cache.top_paths.is_empty() {
+            return Err("no clipboard files cached".into());
+        }
+        (cache.top_paths.clone(), cache.signature.clone())
+    };
+
+    let path_bufs: Vec<PathBuf> = paths.iter().map(PathBuf::from).collect();
+    match materialize_paths(&path_bufs) {
+        Ok((list, pdu, entry_count, total_bytes)) => {
+            let mut cache = CLIP_CACHE
+                .lock()
+                .map_err(|_| "Clipboard cache lock poisoned".to_string())?;
+            if cache.signature == signature {
+                apply_materialized(&mut cache, list, pdu, entry_count, total_bytes);
+            }
             Ok(())
         }
         Err(err) if err == "cliprdr_too_large" => {
-            cache.too_large = true;
-            cache.file_list.clear();
-            cache.files_pdu.clear();
+            let mut cache = CLIP_CACHE
+                .lock()
+                .map_err(|_| "Clipboard cache lock poisoned".to_string())?;
+            if cache.signature == signature {
+                apply_too_large(&mut cache, 0, 0);
+            }
             Err(err)
         }
         Err(err) => Err(err),
@@ -584,7 +628,7 @@ enum ClipboardPathsRead {
 }
 
 #[cfg(windows)]
-fn read_clipboard_paths() -> ClipboardPathsRead {
+fn read_clipboard_paths_once() -> ClipboardPathsRead {
     use windows::Win32::Foundation::{HGLOBAL, HWND};
     use windows::Win32::System::DataExchange::{
         CloseClipboard, GetClipboardData, IsClipboardFormatAvailable, OpenClipboard,
@@ -666,6 +710,23 @@ fn read_clipboard_paths() -> ClipboardPathsRead {
             Some(paths) => ClipboardPathsRead::Paths(paths),
         }
     }
+}
+
+/// Read CF_HDROP with short Busy retries. Must run off the WebView UI thread
+/// (see async command wrappers) — OpenClipboard on that thread self-deadlocks
+/// with WebView2 clipboard handling for ~30s after a local file Copy.
+#[cfg(windows)]
+fn read_clipboard_paths() -> ClipboardPathsRead {
+    const ATTEMPTS: u32 = 8;
+    for i in 0..ATTEMPTS {
+        match read_clipboard_paths_once() {
+            ClipboardPathsRead::Busy if i + 1 < ATTEMPTS => {
+                std::thread::sleep(std::time::Duration::from_millis(15 + 15 * i as u64));
+            }
+            other => return other,
+        }
+    }
+    ClipboardPathsRead::Busy
 }
 
 #[cfg(windows)]
@@ -764,11 +825,10 @@ fn sync_from_paths(paths: Vec<String>, source: CacheSource) -> Result<DesktopCli
         .filter(|p| !p.is_empty())
         .collect();
 
-    let mut cache = CLIP_CACHE
-        .lock()
-        .map_err(|_| "Clipboard cache lock poisoned".to_string())?;
-
     if paths.is_empty() {
+        let mut cache = CLIP_CACHE
+            .lock()
+            .map_err(|_| "Clipboard cache lock poisoned".to_string())?;
         match source {
             CacheSource::Clipboard => {
                 if cache.source == CacheSource::Paths && !cache.files_pdu.is_empty() {
@@ -794,40 +854,93 @@ fn sync_from_paths(paths: Vec<String>, source: CacheSource) -> Result<DesktopCli
     let sigs = fingerprint(&paths);
     let signature = make_signature(&paths, &sigs);
 
-    if cache.source == source && cache.top_paths == paths && cache.sigs == sigs {
-        // Same top-level clipboard selection — do not re-walk directories every poll.
-        return Ok(cache.result());
+    // Fast path: identical selection already assessed/materialized.
+    {
+        let cache = CLIP_CACHE
+            .lock()
+            .map_err(|_| "Clipboard cache lock poisoned".to_string())?;
+        if cache.source == source && cache.top_paths == paths && cache.sigs == sigs {
+            let ready = source == CacheSource::Received
+                || cache.too_large
+                || (!cache.files_pdu.is_empty() && !cache.file_list.is_empty());
+            if ready {
+                return Ok(cache.result());
+            }
+        }
     }
 
-    // Record paths; assess size for outbound Cliprdr (not inbound Received cache).
-    // Full FILEGROUPDESCRIPTOR is still built lazily on FormatDataRequest.
-    cache.file_list.clear();
-    cache.files_pdu.clear();
-    cache.source = source;
-    cache.top_paths = paths.clone();
-    cache.sigs = sigs;
-    cache.signature = signature;
-    cache.too_large = false;
-    cache.entry_count = 0;
-    cache.total_bytes = 0;
+    // Assess + materialize *outside* CLIP_CACHE so FormatData / FileContents /
+    // right-click IPC are never blocked on a directory walk.
+    let path_bufs: Vec<PathBuf> = paths.iter().map(PathBuf::from).collect();
+    let mut too_large = false;
+    let mut entry_count = 0u32;
+    let mut total_bytes = 0u64;
+    let mut file_list: Vec<LocalFileEntry> = Vec::new();
+    let mut files_pdu: Vec<u8> = Vec::new();
 
     if source != CacheSource::Received {
-        let path_bufs: Vec<PathBuf> = paths.iter().map(PathBuf::from).collect();
         match assess_tree(&path_bufs) {
             Ok((entries, bytes, exceeded)) => {
-                cache.entry_count = entries.min(u32::MAX as usize) as u32;
-                cache.total_bytes = bytes;
-                cache.too_large = exceeded;
+                entry_count = entries.min(u32::MAX as usize) as u32;
+                total_bytes = bytes;
                 if exceeded {
+                    too_large = true;
                     eprintln!(
                         "[desktop_clipboard] Cliprdr refusal: {entries} entries / {bytes} bytes exceeds limits — use File transfer"
                     );
+                } else {
+                    // Pre-build FILEGROUPDESCRIPTOR before FormatList so remote
+                    // Explorer context menus get an instant FormatDataResponse
+                    // (lazy-on-FormatData put the walk on the right-click path).
+                    match materialize_paths(&path_bufs) {
+                        Ok((list, pdu, count, bytes_sum)) => {
+                            file_list = list;
+                            files_pdu = pdu;
+                            entry_count = count;
+                            total_bytes = bytes_sum;
+                        }
+                        Err(err) if err == "cliprdr_too_large" => {
+                            too_large = true;
+                            eprintln!(
+                                "[desktop_clipboard] Cliprdr refusal during materialize — use File transfer"
+                            );
+                        }
+                        Err(err) => {
+                            eprintln!("[desktop_clipboard] materialize failed: {err}");
+                        }
+                    }
                 }
             }
             Err(err) => {
                 eprintln!("[desktop_clipboard] assess_tree failed: {err}");
             }
         }
+    }
+
+    let mut cache = CLIP_CACHE
+        .lock()
+        .map_err(|_| "Clipboard cache lock poisoned".to_string())?;
+    cache.source = source;
+    cache.top_paths = paths;
+    cache.sigs = sigs;
+    cache.signature = signature;
+    if too_large {
+        apply_too_large(&mut cache, entry_count, total_bytes);
+    } else if source == CacheSource::Received {
+        cache.too_large = false;
+        cache.entry_count = 0;
+        cache.total_bytes = 0;
+        cache.file_list.clear();
+        cache.files_pdu.clear();
+    } else if !files_pdu.is_empty() {
+        apply_materialized(&mut cache, file_list, files_pdu, entry_count, total_bytes);
+    } else {
+        // Assess/materialize failed — keep paths so a later FormatData can retry.
+        cache.too_large = false;
+        cache.entry_count = entry_count;
+        cache.total_bytes = total_bytes;
+        cache.file_list.clear();
+        cache.files_pdu.clear();
     }
 
     Ok(cache.result())
@@ -854,44 +967,49 @@ fn sync_from_clipboard() -> Result<DesktopClipboardSyncResult, String> {
     }
 }
 
-#[tauri::command]
-pub fn desktop_clipboard_sync() -> Result<DesktopClipboardSyncResult, String> {
-    sync_from_clipboard()
+/// Tauri runs sync `#[command]` fns on the WebView UI thread. OpenClipboard /
+/// large FileContents base64 on that thread freezes input (~30s self-deadlock
+/// after local file Copy) and makes Paste appear hung. Always offload.
+async fn spawn_clip_blocking<T, F>(work: F) -> Result<T, String>
+where
+    T: Send + 'static,
+    F: FnOnce() -> Result<T, String> + Send + 'static,
+{
+    tauri::async_runtime::spawn_blocking(work)
+        .await
+        .map_err(|e| format!("clipboard task join: {e}"))?
 }
 
-#[tauri::command]
-pub fn desktop_clipboard_sync_paths(
-    paths: Vec<String>,
-) -> Result<DesktopClipboardSyncResult, String> {
-    sync_from_paths(paths, CacheSource::Paths)
-}
-
-#[tauri::command]
-pub fn desktop_clipboard_format_data() -> Result<String, String> {
-    let mut cache = CLIP_CACHE
+fn format_data_inner() -> Result<String, String> {
+    ensure_files_ready()?;
+    let cache = CLIP_CACHE
         .lock()
         .map_err(|_| "Clipboard cache lock poisoned".to_string())?;
-    ensure_files_materialized(&mut cache)?;
+    if cache.files_pdu.is_empty() {
+        return Err("no clipboard files cached".into());
+    }
     Ok(b64_encode(&cache.files_pdu))
 }
 
-#[tauri::command]
-pub fn desktop_clipboard_file_contents(
+fn file_contents_inner(
     list_index: i32,
     dw_flags: i32,
     n_position_low: i32,
     n_position_high: i32,
     cb_requested: i32,
 ) -> Result<String, String> {
-    let mut cache = CLIP_CACHE
-        .lock()
-        .map_err(|_| "Clipboard cache lock poisoned".to_string())?;
-    ensure_files_materialized(&mut cache)?;
+    ensure_files_ready()?;
     let idx = list_index as usize;
-    let Some(entry) = cache.file_list.get(idx) else {
-        return Err(format!("invalid file index {list_index}"));
+    let (path, size, is_dir) = {
+        let cache = CLIP_CACHE
+            .lock()
+            .map_err(|_| "Clipboard cache lock poisoned".to_string())?;
+        let Some(entry) = cache.file_list.get(idx) else {
+            return Err(format!("invalid file index {list_index}"));
+        };
+        (entry.path.clone(), entry.size, entry.is_dir)
     };
-    if entry.is_dir {
+    if is_dir {
         return Err("cannot read directory contents".into());
     }
 
@@ -901,7 +1019,7 @@ pub fn desktop_clipboard_file_contents(
     const FILECONTENTS_RANGE: i32 = 0x2;
     if dw_flags & FILECONTENTS_SIZE != 0 && dw_flags & FILECONTENTS_RANGE == 0 {
         // u64 LE = LowPart then HighPart — matches RustDesk/FreeRDP SIZE payload.
-        return Ok(b64_encode(&entry.size.to_le_bytes()));
+        return Ok(b64_encode(&size.to_le_bytes()));
     }
     if dw_flags & FILECONTENTS_RANGE == 0 {
         return Err(format!("unsupported dw_flags {dw_flags}"));
@@ -909,31 +1027,77 @@ pub fn desktop_clipboard_file_contents(
 
     let offset = ((n_position_high as u32 as u64) << 32) | (n_position_low as u32 as u64);
     let length = cb_requested as u32 as u64;
-    if offset > entry.size {
+    if offset > size {
         return Err("invalid read offset".into());
     }
-    let read_size = if offset.saturating_add(length) > entry.size {
-        entry.size - offset
+    let read_size = if offset.saturating_add(length) > size {
+        size - offset
     } else {
         length
     } as usize;
 
-    let mut file = File::open(&entry.path).map_err(store_error)?;
+    // Read outside CLIP_CACHE so concurrent FormatData / sync stay responsive.
+    let mut file = File::open(&path).map_err(store_error)?;
     file.seek(SeekFrom::Start(offset)).map_err(store_error)?;
     let mut buf = vec![0u8; read_size];
     file.read_exact(&mut buf).map_err(store_error)?;
     Ok(b64_encode(&buf))
 }
 
-#[tauri::command]
-pub fn desktop_clipboard_clear() {
+fn clear_cache_inner() {
     if let Ok(mut cache) = CLIP_CACHE.lock() {
         cache.clear();
     }
 }
 
 #[tauri::command]
-pub fn desktop_clipboard_format_names() -> DesktopClipboardFormatNames {
+pub async fn desktop_clipboard_sync() -> Result<DesktopClipboardSyncResult, String> {
+    spawn_clip_blocking(sync_from_clipboard).await
+}
+
+#[tauri::command]
+pub async fn desktop_clipboard_sync_paths(
+    paths: Vec<String>,
+) -> Result<DesktopClipboardSyncResult, String> {
+    spawn_clip_blocking(move || sync_from_paths(paths, CacheSource::Paths)).await
+}
+
+#[tauri::command]
+pub async fn desktop_clipboard_format_data() -> Result<String, String> {
+    spawn_clip_blocking(format_data_inner).await
+}
+
+#[tauri::command]
+pub async fn desktop_clipboard_file_contents(
+    list_index: i32,
+    dw_flags: i32,
+    n_position_low: i32,
+    n_position_high: i32,
+    cb_requested: i32,
+) -> Result<String, String> {
+    spawn_clip_blocking(move || {
+        file_contents_inner(
+            list_index,
+            dw_flags,
+            n_position_low,
+            n_position_high,
+            cb_requested,
+        )
+    })
+    .await
+}
+
+#[tauri::command]
+pub async fn desktop_clipboard_clear() {
+    let _ = spawn_clip_blocking(|| {
+        clear_cache_inner();
+        Ok::<(), String>(())
+    })
+    .await;
+}
+
+#[tauri::command]
+pub async fn desktop_clipboard_format_names() -> DesktopClipboardFormatNames {
     DesktopClipboardFormatNames {
         file_descriptor_format_id: FILEDESCRIPTOR_FORMAT_ID,
         file_descriptor_format_name: FILEDESCRIPTORW_FORMAT_NAME.to_string(),
@@ -943,8 +1107,7 @@ pub fn desktop_clipboard_format_names() -> DesktopClipboardFormatNames {
 }
 
 /// Begin an inbound Cliprdr receive: parse FILEGROUPDESCRIPTORW and prepare temp files.
-#[tauri::command]
-pub fn desktop_clipboard_receive_begin(
+fn receive_begin_inner(
     format_data_base64: String,
 ) -> Result<DesktopClipboardReceiveBeginResult, String> {
     let format_data = b64_decode(&format_data_base64)?;
@@ -1030,10 +1193,16 @@ pub fn desktop_clipboard_receive_begin(
     Ok(DesktopClipboardReceiveBeginResult { files })
 }
 
+#[tauri::command]
+pub async fn desktop_clipboard_receive_begin(
+    format_data_base64: String,
+) -> Result<DesktopClipboardReceiveBeginResult, String> {
+    spawn_clip_blocking(move || receive_begin_inner(format_data_base64)).await
+}
+
 /// Append/write a chunk into a file started by `desktop_clipboard_receive_begin`.
 /// Payload is base64 to avoid JSON number-array IPC (which freezes WebView on GB transfers).
-#[tauri::command]
-pub fn desktop_clipboard_receive_write(
+fn receive_write_inner(
     list_index: i32,
     offset: u64,
     data_base64: String,
@@ -1062,12 +1231,20 @@ pub fn desktop_clipboard_receive_write(
     Ok(())
 }
 
+#[tauri::command]
+pub async fn desktop_clipboard_receive_write(
+    list_index: i32,
+    offset: u64,
+    data_base64: String,
+) -> Result<(), String> {
+    spawn_clip_blocking(move || receive_write_inner(list_index, offset, data_base64)).await
+}
+
 /// Place received top-level paths on the local CF_HDROP clipboard.
 ///
 /// Clipboard write is best-effort: if OpenClipboard fails (busy / OLE), we still
 /// return the temp paths so remote→local OLE drag-out can proceed.
-#[tauri::command]
-pub fn desktop_clipboard_receive_commit() -> Result<DesktopClipboardSyncResult, String> {
+fn receive_commit_inner() -> Result<DesktopClipboardSyncResult, String> {
     let mut slot = RECEIVE_SESSION
         .lock()
         .map_err(|_| "Receive session lock poisoned".to_string())?;
@@ -1101,6 +1278,11 @@ pub fn desktop_clipboard_receive_commit() -> Result<DesktopClipboardSyncResult, 
     Ok(result)
 }
 
+#[tauri::command]
+pub async fn desktop_clipboard_receive_commit() -> Result<DesktopClipboardSyncResult, String> {
+    spawn_clip_blocking(receive_commit_inner).await
+}
+
 #[cfg(windows)]
 fn write_clipboard_paths_retry(paths: &[PathBuf], attempts: u32) -> Result<(), String> {
     let mut last = String::new();
@@ -1123,11 +1305,19 @@ fn write_clipboard_paths_retry(paths: &[PathBuf], _attempts: u32) -> Result<(), 
     write_clipboard_paths(paths)
 }
 
-#[tauri::command]
-pub fn desktop_clipboard_receive_abort() {
+fn receive_abort_inner() {
     if let Ok(mut slot) = RECEIVE_SESSION.lock() {
         abort_receive_locked(&mut slot);
     }
+}
+
+#[tauri::command]
+pub async fn desktop_clipboard_receive_abort() {
+    let _ = spawn_clip_blocking(|| {
+        receive_abort_inner();
+        Ok::<(), String>(())
+    })
+    .await;
 }
 
 #[cfg(test)]
@@ -1151,16 +1341,10 @@ mod tests {
         let parsed = parse_files_pdu(&pdu).expect("parse");
         assert_eq!(parsed.len(), 1);
         assert_eq!(parsed[0].0, "hello.txt");
-        // Outbound omits FD_FILESIZE (RustDesk compatibility), so parse sees size 0
-        // unless FLAGS_FD_SIZE is set. Size fields are still present for probes.
+        assert_eq!(parsed[0].1, 42);
         assert!(!parsed[0].2);
-        // Descriptor layout: size_low at offset 4+68 within PDU.
-        let size_low = u32::from_le_bytes(pdu[4 + 68..4 + 72].try_into().unwrap());
-        let size_high = u32::from_le_bytes(pdu[4 + 64..4 + 68].try_into().unwrap());
-        let raw_size = ((size_high as u64) << 32) | (size_low as u64);
-        assert_eq!(raw_size, 42);
         let flags = u32::from_le_bytes(pdu[4..8].try_into().unwrap());
-        assert_eq!(flags & FLAGS_FD_SIZE, 0, "outbound must omit FD_FILESIZE");
+        assert_ne!(flags & FLAGS_FD_SIZE, 0, "outbound must advertise FD_FILESIZE");
         assert_ne!(flags & FLAGS_FD_PROGRESSUI, 0);
         // Must not set Windows FD_CREATETIME (0x08) — old bug treated it as unix mode.
         assert_eq!(flags & 0x08, 0, "must not set FD_CREATETIME/0x08");
@@ -1214,5 +1398,101 @@ mod tests {
         let _ = fs::remove_dir_all(&dir);
         assert!(exceeded, "expected too-large, got entries={entries}");
         assert!(entries > CLIPRDR_MAX_ENTRIES);
+    }
+
+    #[test]
+    fn sync_from_paths_prematerializes_descriptor() {
+        let dir = std::env::temp_dir().join(format!(
+            "betterdesk-cliprdr-sync-{}",
+            std::process::id()
+        ));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).expect("mkdir");
+        let file = dir.join("note.txt");
+        fs::write(&file, b"hello-cliprdr").expect("write");
+
+        let result = sync_from_paths(
+            vec![file.to_string_lossy().into_owned()],
+            CacheSource::Clipboard,
+        )
+        .expect("sync");
+        assert!(result.has_files);
+        assert!(!result.too_large);
+        assert!(!result.signature.is_empty());
+
+        // FormatData must be a cache hit (no second walk) after sync.
+        let b64 = format_data_inner().expect("format_data");
+        let bytes = b64_decode(&b64).expect("b64");
+        assert!(bytes.len() >= 4 + FILEDESCRIPTORW_SIZE);
+        let count = u32::from_le_bytes(bytes[0..4].try_into().unwrap());
+        assert_eq!(count, 1);
+
+        // FileContents RANGE must return real bytes (not empty) for paste progress.
+        let chunk_b64 = file_contents_inner(0, 0x2, 0, 0, 5).expect("range");
+        let chunk = b64_decode(&chunk_b64).expect("chunk b64");
+        assert_eq!(chunk.as_slice(), b"hello");
+
+        clear_cache_inner();
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn single_file_sync_and_contents_are_fast() {
+        let dir = std::env::temp_dir().join(format!(
+            "betterdesk-cliprdr-5mb-{}",
+            std::process::id()
+        ));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).expect("mkdir");
+        let file = dir.join("five.bin");
+        let payload = vec![0xABu8; 5 * 1024 * 1024];
+        fs::write(&file, &payload).expect("write 5MB");
+
+        let started = std::time::Instant::now();
+        let result = sync_from_paths(
+            vec![file.to_string_lossy().into_owned()],
+            CacheSource::Clipboard,
+        )
+        .expect("sync");
+        let sync_ms = started.elapsed().as_millis();
+        assert!(result.has_files);
+        assert!(!result.too_large);
+        // Metadata-only assess/materialize must not scale with file bytes.
+        assert!(
+            sync_ms < 2_000,
+            "sync took {sync_ms}ms — must not read 5MB into the descriptor"
+        );
+
+        let started = std::time::Instant::now();
+        let b64 = format_data_inner().expect("format_data");
+        let format_ms = started.elapsed().as_millis();
+        assert!(format_ms < 500, "FormatData took {format_ms}ms");
+        let bytes = b64_decode(&b64).expect("b64");
+        assert!(bytes.len() < 8_192, "descriptor must not embed file bytes");
+
+        let started = std::time::Instant::now();
+        let chunk_b64 = file_contents_inner(0, 0x2, 0, 0, 64 * 1024).expect("range");
+        let range_ms = started.elapsed().as_millis();
+        let chunk = b64_decode(&chunk_b64).expect("chunk");
+        assert_eq!(chunk.len(), 64 * 1024);
+        assert_eq!(chunk[0], 0xAB);
+        assert!(
+            range_ms < 2_000,
+            "64KiB FileContents took {range_ms}ms"
+        );
+
+        clear_cache_inner();
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn format_data_does_not_need_cache_lock_during_walk_smoke() {
+        // After clear, FormatData fails fast without hanging.
+        clear_cache_inner();
+        let err = format_data_inner().expect_err("empty cache");
+        assert!(
+            err.contains("no clipboard files") || err.contains("cliprdr"),
+            "unexpected err={err}"
+        );
     }
 }

--- a/web-nodejs/public/js/rdclient/clipboard.js
+++ b/web-nodejs/public/js/rdclient/clipboard.js
@@ -213,30 +213,34 @@ class RDClipboard {
      * @param {Object[]} decodedEntries
      * @param {Object} [opts]
      * @param {boolean} [opts.enabled]
-     * @returns {Promise<void>}
+     * @returns {Promise<{wrote: boolean, text: string}>}
      */
     static async applyToLocal(decodedEntries, opts) {
+        const empty = { wrote: false, text: '' };
         const options = opts || {};
-        if (!options.enabled) return;
-        if (!navigator.clipboard) return;
+        if (!options.enabled) return empty;
+        if (!navigator.clipboard) return empty;
 
         const entries = (decodedEntries || []).filter(Boolean);
-        if (!entries.length) return;
+        if (!entries.length) return empty;
 
         const text = RDClipboard.pickBestText(entries);
         const htmlEntry = entries.find((e) => e.format === 'html' && e.html);
         const pngEntry = entries.find((e) => e.pngBlob);
         const svgEntry = entries.find((e) => e.format === 'image/svg+xml' && e.svgText);
+        const result = { wrote: false, text: text || '' };
 
         try {
             if (pngEntry && navigator.clipboard.write && typeof ClipboardItem !== 'undefined') {
                 await navigator.clipboard.write([new ClipboardItem({ 'image/png': pngEntry.pngBlob })]);
-                return;
+                result.wrote = true;
+                return result;
             }
             if (svgEntry && navigator.clipboard.write && typeof ClipboardItem !== 'undefined') {
                 const blob = new Blob([svgEntry.svgText], { type: 'image/svg+xml' });
                 await navigator.clipboard.write([new ClipboardItem({ 'image/svg+xml': blob })]);
-                return;
+                result.wrote = true;
+                return result;
             }
             if (htmlEntry && navigator.clipboard.write && typeof ClipboardItem !== 'undefined') {
                 const plain = htmlEntry.text || RDClipboard.stripHtml(htmlEntry.html);
@@ -244,20 +248,27 @@ class RDClipboard {
                     'text/html': new Blob([htmlEntry.html], { type: 'text/html' }),
                     'text/plain': new Blob([plain], { type: 'text/plain' })
                 })]);
-                return;
+                result.wrote = true;
+                result.text = plain || result.text;
+                return result;
             }
             if (text && navigator.clipboard.writeText) {
                 await navigator.clipboard.writeText(text);
+                result.wrote = true;
+                return result;
             }
         } catch (err) {
             if (text && navigator.clipboard.writeText) {
                 try {
                     await navigator.clipboard.writeText(text);
+                    result.wrote = true;
+                    return result;
                 } catch (_) {
-                    // permission denied — ignore
+                    // permission denied / no user gesture — caller may stash text
                 }
             }
         }
+        return result;
     }
 
     /**

--- a/web-nodejs/public/js/rdclient/cliprdr.js
+++ b/web-nodejs/public/js/rdclient/cliprdr.js
@@ -158,6 +158,17 @@
         static FILEDESCRIPTOR_FORMAT_NAME = 'FileGroupDescriptorW';
         static FILECONTENTS_FORMAT_NAME = 'FileContents';
 
+        /**
+         * Right/middle-click must not kick off Cliprdr IPC. Remote Explorer builds
+         * its context menu via FormatData; concurrent sync holding the desktop
+         * cache lock (or re-walking trees) stalls that path for tens of seconds.
+         * @param {MouseEvent|{button?: number}|null|undefined} ev
+         * @returns {boolean}
+         */
+        static shouldSyncOnUserGesture(ev) {
+            if (!ev || typeof ev.button !== 'number') return true;
+            return ev.button === 0;
+        }
         static isSupported() {
             return isDesktopBridge();
         }
@@ -273,10 +284,8 @@
             client._cliprdrPollTimer = setInterval(function () {
                 if (client._state !== 'streaming' || client.viewOnly) return;
                 if (client._cliprdrSyncInFlight || client._cliprdrReceiving) return;
-                client._cliprdrSyncInFlight = true;
-                Promise.resolve(RDCliprdr.syncLocalFiles(client)).finally(function () {
-                    client._cliprdrSyncInFlight = false;
-                });
+                // Fire-and-forget — never await on the timer tick (input path).
+                void RDCliprdr.syncLocalFiles(client);
             }, CLIP_POLL_MS);
         }
 
@@ -303,77 +312,105 @@
                 return { hasFiles: false, signature: client._cliprdrLocalSignature || '', busy: false };
             }
 
-            var sync;
+            // Clipboard polls (focus/click/timer) must not stack. DnD paths always run.
+            var fromClipboard = !(paths && paths.length);
+            if (fromClipboard && client._cliprdrSyncInFlight) {
+                client._cliprdrSyncQueued = true;
+                debugLog('syncPaths skipped: already in flight (queued follow-up)');
+                return {
+                    hasFiles: !!client._cliprdrLocalSignature,
+                    signature: client._cliprdrLocalSignature || '',
+                    busy: true
+                };
+            }
+            if (fromClipboard) {
+                client._cliprdrSyncInFlight = true;
+                client._cliprdrSyncQueued = false;
+            }
+
             try {
-                if (paths && paths.length) {
-                    sync = await desktopInvoke('desktop_clipboard_sync_paths', { paths: paths });
-                } else {
-                    sync = await desktopInvoke('desktop_clipboard_sync');
-                }
-            } catch (err) {
-                console.warn('[RDCliprdr] sync failed:', err);
-                return { hasFiles: false, signature: '', busy: false };
-            }
-
-            debugLog('sync result:', sync, paths ? paths.length + ' path(s) supplied' : 'clipboard poll');
-
-            if (sync && sync.busy) {
-                return sync;
-            }
-
-            if (!sync || !sync.hasFiles) {
-                if (!paths) client._cliprdrLocalSignature = '';
-                return sync || { hasFiles: false, signature: '', busy: false };
-            }
-
-            var signature = sync.signature || '';
-            var tooLarge = !!(sync.tooLarge || sync.too_large);
-            // DnD paths must always re-advertise + auto-paste even if signature matches
-            // a prior clipboard copy of the same files.
-            var forceAdvertise = !!(paths && paths.length);
-            if (!forceAdvertise && signature && signature === client._cliprdrLocalSignature) {
-                return sync;
-            }
-            client._cliprdrLocalSignature = signature;
-
-            // Large folder trees freeze remote Explorer over the shared desktop
-            // relay — refuse Cliprdr and steer to dedicated File transfer.
-            if (tooLarge) {
-                console.warn(
-                    '[RDCliprdr] selection too large for Cliprdr paste (' +
-                    (sync.entryCount || sync.entry_count || '?') + ' entries / ' +
-                    (sync.totalBytes || sync.total_bytes || '?') +
-                    ' bytes) — use File transfer'
-                );
+                var sync;
                 try {
-                    client._emit('cliprdr_too_large', {
-                        signature: signature,
-                        entryCount: Number(sync.entryCount != null ? sync.entryCount : (sync.entry_count || 0)),
-                        totalBytes: Number(sync.totalBytes != null ? sync.totalBytes : (sync.total_bytes || 0))
-                    });
-                } catch (_) { /* ignore */ }
+                    if (paths && paths.length) {
+                        sync = await desktopInvoke('desktop_clipboard_sync_paths', { paths: paths });
+                    } else {
+                        sync = await desktopInvoke('desktop_clipboard_sync');
+                    }
+                } catch (err) {
+                    console.warn('[RDCliprdr] sync failed:', err);
+                    return { hasFiles: false, signature: '', busy: false };
+                }
+
+                debugLog('sync result:', sync, paths ? paths.length + ' path(s) supplied' : 'clipboard poll');
+
+                if (sync && sync.busy) {
+                    return sync;
+                }
+
+                if (!sync || !sync.hasFiles) {
+                    if (!paths) client._cliprdrLocalSignature = '';
+                    return sync || { hasFiles: false, signature: '', busy: false };
+                }
+
+                var signature = sync.signature || '';
+                var tooLarge = !!(sync.tooLarge || sync.too_large);
+                // DnD paths must always re-advertise + auto-paste even if signature matches
+                // a prior clipboard copy of the same files.
+                var forceAdvertise = !!(paths && paths.length);
+                if (!forceAdvertise && signature && signature === client._cliprdrLocalSignature) {
+                    return sync;
+                }
+                client._cliprdrLocalSignature = signature;
+
+                // Large folder trees freeze remote Explorer over the shared desktop
+                // relay — refuse Cliprdr and steer to dedicated File transfer.
+                if (tooLarge) {
+                    console.warn(
+                        '[RDCliprdr] selection too large for Cliprdr paste (' +
+                        (sync.entryCount || sync.entry_count || '?') + ' entries / ' +
+                        (sync.totalBytes || sync.total_bytes || '?') +
+                        ' bytes) — use File transfer'
+                    );
+                    try {
+                        client._emit('cliprdr_too_large', {
+                            signature: signature,
+                            entryCount: Number(sync.entryCount != null ? sync.entryCount : (sync.entry_count || 0)),
+                            totalBytes: Number(sync.totalBytes != null ? sync.totalBytes : (sync.total_bytes || 0))
+                        });
+                    } catch (_) { /* ignore */ }
+                    return sync;
+                }
+
+                debugLog('FormatList', paths ? paths.length + ' path(s)' : 'clipboard');
+                if (client._cliprdrFormatNames == null) {
+                    client._cliprdrFormatNames = await desktopInvoke('desktop_clipboard_format_names').catch(function () { return null; });
+                }
+
+                var formatListAck = null;
+                if (forceAdvertise) {
+                    formatListAck = RDCliprdr._waitFormatListAck(client, 2500);
+                }
+                // Never await FormatList ACK on the clipboard/focus path — that would
+                // delay click delivery. DnD auto-paste waits separately.
+                client._sendPeerMessage(client.proto.buildCliprdrFormatList(
+                    client._cliprdrFormatNames || undefined
+                ));
+
+                // Explicit paths = OS drag-drop onto the viewer — focus the drop
+                // point on the remote, wait briefly for FormatList ack, then Ctrl+V.
+                if (forceAdvertise && client.input) {
+                    RDCliprdr._autoPasteAfterDrop(client, position, formatListAck);
+                }
                 return sync;
+            } finally {
+                if (fromClipboard) {
+                    client._cliprdrSyncInFlight = false;
+                    if (client._cliprdrSyncQueued) {
+                        client._cliprdrSyncQueued = false;
+                        void RDCliprdr.syncLocalFiles(client);
+                    }
+                }
             }
-
-            debugLog('FormatList', paths ? paths.length + ' path(s)' : 'clipboard');
-            if (client._cliprdrFormatNames == null) {
-                client._cliprdrFormatNames = await desktopInvoke('desktop_clipboard_format_names').catch(function () { return null; });
-            }
-
-            var formatListAck = null;
-            if (forceAdvertise) {
-                formatListAck = RDCliprdr._waitFormatListAck(client, 2500);
-            }
-            client._sendPeerMessage(client.proto.buildCliprdrFormatList(
-                client._cliprdrFormatNames || undefined
-            ));
-
-            // Explicit paths = OS drag-drop onto the viewer — focus the drop
-            // point on the remote, wait briefly for FormatList ack, then Ctrl+V.
-            if (forceAdvertise && client.input) {
-                RDCliprdr._autoPasteAfterDrop(client, position, formatListAck);
-            }
-            return sync;
         }
 
         static _waitFormatListAck(client, timeoutMs) {

--- a/web-nodejs/public/js/remote.js
+++ b/web-nodejs/public/js/remote.js
@@ -502,26 +502,106 @@
     // The browser cannot observe clipboard changes, but it can read the
     // clipboard once the tab regains focus (with transient activation), so we
     // push the current local clipboard to the active streaming session then.
+    //
+    // Never run this on right/middle-click: Desktop Cliprdr sync + FormatData
+    // share a cache lock with remote Explorer context-menu probes.
+    //
+    // Focus/left-click must stay fire-and-forget: sync Tauri clipboard commands
+    // on the WebView UI thread self-deadlock OpenClipboard after a local file
+    // Copy (~30s) and freeze click/menu delivery.
+    //
+    // Critical: Explorer file copies also expose a path as CF_UNICODETEXT.
+    // Sending that text Clipboard message after Cliprdr FormatList clears file
+    // formats on the peer — always syncCliprdrFiles first and skip text when
+    // CF_HDROP is present (this is what made Paste appear to "do nothing").
+    function _clipDebug() {
+        if (window.BetterDesk && window.BetterDesk.debugRelay) {
+            console.log.apply(console, ['[ClipboardSync]'].concat(Array.prototype.slice.call(arguments)));
+        }
+    }
     let _lastSyncedClipboard = '';
-    async function syncLocalClipboardToRemote() {
+    let _clipSyncTimer = null;
+    let _clipSyncQueued = false;
+    async function syncLocalClipboardToRemote(ev) {
+        if (typeof RDCliprdr !== 'undefined'
+            && typeof RDCliprdr.shouldSyncOnUserGesture === 'function'
+            && !RDCliprdr.shouldSyncOnUserGesture(ev)) {
+            _clipDebug('skip: non-left mouse button (keep remote context menu responsive)');
+            return;
+        }
         const session = getActiveSession();
-        if (!session || !session.client || session.state !== 'streaming') return;
-        if (session.client.viewOnly) return;
-        if (!navigator.clipboard || !navigator.clipboard.readText) return;
+        if (!session || !session.client || session.state !== 'streaming') {
+            _clipDebug('skip: no active streaming session', session && session.state);
+            return;
+        }
+        if (session.client.viewOnly) {
+            _clipDebug('skip: view-only session');
+            return;
+        }
+        if (session.client._lastSyncedClipboardHint) {
+            _lastSyncedClipboard = session.client._lastSyncedClipboardHint;
+        }
+        let hasFiles = false;
+        if (window.__BETTERDESK_RDCLIENT_DESKTOP__ && typeof RDCliprdr !== 'undefined' && RDCliprdr.isSupported()) {
+            _clipDebug('desktop bridge detected -> syncCliprdrFiles()');
+            try {
+                const sync = await session.client.syncCliprdrFiles();
+                hasFiles = !!(sync && sync.hasFiles);
+                if (sync && sync.busy) {
+                    _clipDebug('Cliprdr sync busy — skipping text push');
+                    return;
+                }
+            } catch (err) {
+                _clipDebug('syncCliprdrFiles failed:', err && err.message ? err.message : err);
+            }
+        } else if (window.__BETTERDESK_RDCLIENT_DESKTOP__) {
+            _clipDebug('desktop flag set but RDCliprdr.isSupported() is false — check window.__TAURI__.core.invoke');
+        }
+        if (hasFiles) {
+            _clipDebug('skip text clipboard: local file clipboard (CF_HDROP) present');
+            return;
+        }
+        if (typeof session.client.flushPendingLocalClipboard === 'function') {
+            try {
+                await session.client.flushPendingLocalClipboard();
+            } catch (_) { /* ignore */ }
+        }
+        if (!navigator.clipboard || !navigator.clipboard.readText) {
+            _clipDebug('skip: navigator.clipboard.readText unavailable in this webview');
+            return;
+        }
         try {
             const text = await navigator.clipboard.readText();
+            _clipDebug('readText() ok, length=', text ? text.length : 0);
             if (text && text !== _lastSyncedClipboard) {
                 _lastSyncedClipboard = text;
                 session.client.sendClipboard(text);
+                _clipDebug('sendClipboard() called');
             }
-        } catch {
-            // Permission denied or not focused — ignore, the manual paste
-            // button remains available as a fallback.
+        } catch (err) {
+            _clipDebug('readText() FAILED:', err && err.message ? err.message : err);
         }
     }
-    window.addEventListener('focus', syncLocalClipboardToRemote);
+    function scheduleLocalClipboardSync(ev) {
+        if (typeof RDCliprdr !== 'undefined'
+            && typeof RDCliprdr.shouldSyncOnUserGesture === 'function'
+            && !RDCliprdr.shouldSyncOnUserGesture(ev)) {
+            return;
+        }
+        _clipSyncQueued = true;
+        if (_clipSyncTimer) return;
+        _clipSyncTimer = setTimeout(function () {
+            _clipSyncTimer = null;
+            if (!_clipSyncQueued) return;
+            _clipSyncQueued = false;
+            void syncLocalClipboardToRemote({ button: 0 });
+        }, 200);
+    }
+    window.addEventListener('focus', function () {
+        void syncLocalClipboardToRemote(null);
+    });
     if (viewerContainer) {
-        viewerContainer.addEventListener('mousedown', syncLocalClipboardToRemote);
+        viewerContainer.addEventListener('mousedown', scheduleLocalClipboardSync);
     }
 
 
@@ -987,6 +1067,16 @@
         c.on('signature_warning', (msg) => {
             console.warn('[Remote] Signature warning:', msg);
             showSecurityWarning(session, msg, 'warning');
+        });
+        c.on('cliprdr_too_large', (info) => {
+            const sig = (info && info.signature) || '';
+            if (sig && session._cliprdrTooLargeToastSig === sig) return;
+            if (sig) session._cliprdrTooLargeToastSig = sig;
+            showToast(
+                _('remote.cliprdr_use_file_transfer')
+                || 'This folder is too large for clipboard paste. Use File transfer to avoid freezing the remote desktop.',
+                'warning'
+            );
         });
         c.on('encryption_warning', (msg) => {
             console.warn('[Remote] Encryption warning:', msg);

--- a/web-nodejs/tests/rdclient.clipboard.test.js
+++ b/web-nodejs/tests/rdclient.clipboard.test.js
@@ -113,6 +113,29 @@ describe('RDClipboard helpers', () => {
         expect(decoded).toHaveLength(1);
         expect(decoded[0].text).toBe('kept');
     });
+
+    it('applyToLocal returns wrote=true when writeText succeeds', async () => {
+        const sandbox = loadRdclientModules();
+        const writeText = sandbox.navigator.clipboard.writeText;
+        writeText.mockResolvedValue(undefined);
+        const result = await sandbox.RDClipboard.applyToLocal(
+            [{ format: 'text', text: 'remote line' }],
+            { enabled: true }
+        );
+        expect(result).toEqual({ wrote: true, text: 'remote line' });
+        expect(writeText).toHaveBeenCalledWith('remote line');
+    });
+
+    it('applyToLocal returns wrote=false and stashes text when write fails', async () => {
+        const sandbox = loadRdclientModules();
+        sandbox.navigator.clipboard.writeText.mockRejectedValue(new Error('denied'));
+        const result = await sandbox.RDClipboard.applyToLocal(
+            [{ format: 'text', text: 'stash me' }],
+            { enabled: true }
+        );
+        expect(result.wrote).toBe(false);
+        expect(result.text).toBe('stash me');
+    });
 });
 
 describe('RDCompress helpers', () => {
@@ -131,6 +154,97 @@ describe('RDCompress helpers', () => {
         const raw = new Uint8Array([72, 105]);
         const out = await RDCompress.decompressZstd(raw);
         expect(Array.from(out)).toEqual([72, 105]);
+    });
+});
+
+describe('RDCliprdr gesture gating', () => {
+    let RDCliprdr;
+    let sandbox;
+
+    beforeAll(() => {
+        sandbox = {
+            console,
+            Uint8Array,
+            ArrayBuffer,
+            setTimeout,
+            clearTimeout,
+            Promise,
+            window: {
+                __BETTERDESK_RDCLIENT_DESKTOP__: true,
+                __TAURI__: { core: { invoke: async () => ({}) } }
+            },
+            globalThis: {}
+        };
+        sandbox.globalThis = sandbox;
+        sandbox.window = Object.assign(sandbox.window, { BetterDesk: undefined });
+        // Minimal stubs so cliprdr.js can define RDCliprdr without LocalFiles.
+        const base = path.join(__dirname, '..', 'public/js/rdclient');
+        vm.runInNewContext(
+            fs.readFileSync(path.join(base, 'cliprdr.js'), 'utf8'),
+            sandbox,
+            { filename: 'cliprdr.js' }
+        );
+        RDCliprdr = sandbox.RDCliprdr || sandbox.window.RDCliprdr;
+    });
+
+    it('skips Cliprdr sync on right/middle mouse button', () => {
+        expect(RDCliprdr.shouldSyncOnUserGesture({ button: 2 })).toBe(false);
+        expect(RDCliprdr.shouldSyncOnUserGesture({ button: 1 })).toBe(false);
+        expect(RDCliprdr.shouldSyncOnUserGesture({ button: 0 })).toBe(true);
+        expect(RDCliprdr.shouldSyncOnUserGesture(null)).toBe(true);
+        expect(RDCliprdr.shouldSyncOnUserGesture(undefined)).toBe(true);
+    });
+
+    it('coalesces clipboard sync while one invoke is in flight', async () => {
+        let resolveSync;
+        const syncPromise = new Promise((resolve) => { resolveSync = resolve; });
+        let invokeCount = 0;
+        sandbox.window.__TAURI__.core.invoke = async (cmd) => {
+            if (cmd === 'desktop_clipboard_sync') {
+                invokeCount += 1;
+                return syncPromise;
+            }
+            if (cmd === 'desktop_clipboard_format_names') {
+                return {
+                    fileDescriptorFormatId: 49334,
+                    fileDescriptorFormatName: 'FileGroupDescriptorW',
+                    fileContentsFormatId: 49267,
+                    fileContentsFormatName: 'FileContents'
+                };
+            }
+            return {};
+        };
+
+        const sent = [];
+        const client = {
+            _state: 'streaming',
+            viewOnly: false,
+            proto: {
+                buildCliprdrFormatList: () => ({ cliprdr: { formatList: {} } })
+            },
+            _sendPeerMessage: (msg) => { sent.push(msg); },
+            _emit: () => {}
+        };
+
+        const first = RDCliprdr.syncLocalFiles(client);
+        const second = await RDCliprdr.syncLocalFiles(client);
+        expect(second.busy).toBe(true);
+        expect(invokeCount).toBe(1);
+
+        resolveSync({
+            hasFiles: true,
+            signature: 'sig-a',
+            busy: false,
+            tooLarge: false,
+            entryCount: 1,
+            totalBytes: 5
+        });
+        const firstResult = await first;
+        expect(firstResult.hasFiles).toBe(true);
+        expect(sent.length).toBeGreaterThanOrEqual(1);
+        // Queued follow-up may start after first finishes.
+        await new Promise((r) => setTimeout(r, 20));
+        expect(invokeCount).toBeGreaterThanOrEqual(1);
     });
 });
 


### PR DESCRIPTION
## Summary
- **Root cause:** `UNITRONIX/dev` never received the fork Cliprdr recoveries that landed only on `Chesster1981/dev`. Panel Settings → Updates pulls from UNITRONIX by default, so operators kept running broken panel JS + (often) mismatched desktop binaries.
- **Why Paste looked dead:** `remote.js` synced path-as-text on every mousedown and never called `syncCliprdrFiles`, wiping Cliprdr FormatList after the poll advertised files.
- **Why the ~1 min context-menu hang:** outbound descriptors omitted `FD_FILESIZE`, so remote Explorer blocked on `FILECONTENTS_SIZE` probes over the desktop relay. The old 0 KB bug was base64 coerce + mistyped `FD_CREATETIME` (0x08), not `FD_FILESIZE` itself.
- **Also:** clipboard Tauri IPC is now `async` + `spawn_blocking` so OpenClipboard no longer deadlocks the WebView UI thread after a local Explorer Copy.

## Test plan
- [ ] Panel on Development channel: Settings → Updates → apply this commit (or merge to `dev` first)
- [ ] Rebuild `rdclient-desktop` from this branch; quit any installed AppData RdClient; run the new binary (`npm run dev` or `dist-release/rdclient-desktop.exe`)
- [ ] Copy a ~5MB local file in Explorer → focus RdClient session → right-click remote Explorer: context menu appears quickly (not ~1 minute)
- [ ] Paste: remote file size matches local; transfer shows progress
- [ ] `npm test -- --testPathPattern=rdclient.clipboard` and `cargo test --lib desktop_clipboard` pass

Refs: fork commits `f6fc13cb` (omit), `5cc304fb` (restore FD_FILESIZE), `129c6cbe` / `0ac16eec` (UI), `d02c87df` (base64).

Made with [Cursor](https://cursor.com)