### PR TITLE
fix: wire up peer-grant methods in the database facade (fixes #380)

### DIFF
--- a/web-nodejs/services/database.js
+++ b/web-nodejs/services/database.js
@@ -160,6 +160,10 @@ const facade = {
     clearAccountLockout:  (username) => adapter.clearAccountLockout(username),
     cleanupOldLoginAttempts: () => adapter.cleanupOldLoginAttempts(),
 
+    // ---- Peer Grants (per-user device access) ----
+    getUserPeerGrants: (userId) => adapter.getUserPeerGrants(userId),
+    setUserPeerGrants: (userId, peerIds) => adapter.setUserPeerGrants(userId, peerIds),
+
     // ---- Address Books ----
     getAddressBook:     (userId, abType) => adapter.getAddressBook(userId, abType),
     saveAddressBook:    (userId, data, abType) => adapter.saveAddressBook(userId, abType || 'legacy', data),

--- a/web-nodejs/tests/database.peerGrants.test.js
+++ b/web-nodejs/tests/database.peerGrants.test.js
@@ -1,0 +1,78 @@
+'use strict';
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+/**
+ * Regression test for the `database.js` facade silently dropping peer-grant
+ * calls: `userScopeService.syncUserPeerGrants()` / `getUserPeerGrantIds()`
+ * both guard on `typeof db.setUserPeerGrants !== 'function'` /
+ * `typeof db.getUserPeerGrants !== 'function'` and quietly no-op (returning
+ * `[]`, no error, no log) when the facade doesn't expose those methods —
+ * even though the underlying adapter (dbAdapter.js) implements them fully
+ * for both SQLite and Postgres. `POST /api/users` and `PATCH /api/users/:id`
+ * both reported `{"success":true}` while never persisting a single row to
+ * `user_peer_grants`.
+ *
+ * This is deliberately NOT a route-level test with a mocked `database`
+ * module (see users.routes.test.js, which mocks `../services/database`
+ * wholesale) — a mock can't catch the real facade omitting a method, which
+ * is exactly how this slipped through. This test requires the real facade
+ * against a temp SQLite file, the same way dbAdapter.singleStore.test.js
+ * does for other facade/adapter wiring.
+ */
+describe('database facade — peer grants', () => {
+    let tempDir;
+
+    beforeEach(() => {
+        tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'betterdesk-peer-grants-'));
+        process.env.DATA_DIR = path.join(tempDir, 'panel-data');
+        process.env.DB_PATH = path.join(tempDir, 'db_v2.sqlite3');
+        process.env.DB_TYPE = 'sqlite';
+        jest.resetModules();
+    });
+
+    afterEach(() => {
+        delete process.env.DATA_DIR;
+        delete process.env.DB_PATH;
+        delete process.env.DB_TYPE;
+        fs.rmSync(tempDir, { recursive: true, force: true });
+    });
+
+    it('exposes getUserPeerGrants/setUserPeerGrants as functions (guarded on by userScopeService)', () => {
+        const db = require('../services/database');
+        expect(typeof db.getUserPeerGrants).toBe('function');
+        expect(typeof db.setUserPeerGrants).toBe('function');
+    });
+
+    it('round-trips a peer grant through the real facade, not just the adapter', async () => {
+        const db = require('../services/database');
+        await db.init();
+
+        const user = await db.createUser('grant-test-user', 'hashed', 'operator');
+
+        await db.setUserPeerGrants(user.id, ['1234567890', '1234567890', ' 42 ']);
+        const grants = await db.getUserPeerGrants(user.id);
+
+        expect(grants.sort()).toEqual(['1234567890', '42']);
+
+        await db.close();
+    });
+
+    it('userScopeService.syncUserPeerGrants actually persists via the real facade', async () => {
+        const db = require('../services/database');
+        const userScopeService = require('../services/userScopeService');
+        await db.init();
+
+        const user = await db.createUser('grant-test-user-2', 'hashed', 'viewer');
+
+        const normalized = await userScopeService.syncUserPeerGrants(db, user.id, ['999888777']);
+        expect(normalized).toEqual(['999888777']);
+
+        const stored = await userScopeService.getUserPeerGrantIds(db, user.id);
+        expect(stored).toEqual(['999888777']);
+
+        await db.close();
+    });
+});


### PR DESCRIPTION
Fixes #380.

## Root cause

`web-nodejs/services/database.js` is a hand-maintained facade over `dbAdapter.js` — it re-exports adapter methods under their legacy names, one line per method. `getUserPeerGrants` / `setUserPeerGrants` are fully implemented in `dbAdapter.js` for **both** the SQLite and Postgres branches, but were never added to the facade object.

`userScopeService.js` guards on this:

```js
async function syncUserPeerGrants(db, userId, peerIds) {
    if (!userId || typeof db.setUserPeerGrants !== 'function') return [];
    ...
}
```

Since the facade doesn't expose `setUserPeerGrants`, this silently returns `[]` — no error, no log. `POST /api/users` and `PATCH /api/users/:id` both call this scope-sync step *after* the DB write already succeeded, and respond `{"success":true}` regardless of what the scope sync did. So per-user device grants passed via `peerIds` looked like they worked (200 response, no error anywhere) but never persisted a single row to `user_peer_grants`, for any role.

## Fix

Two missing lines in the facade:

```js
getUserPeerGrants: (userId) => adapter.getUserPeerGrants(userId),
setUserPeerGrants: (userId, peerIds) => adapter.setUserPeerGrants(userId, peerIds),
```

## Test

Added `tests/database.peerGrants.test.js`. Deliberately **not** a route-level test with a mocked `database` module — `users.routes.test.js` already mocks `../services/database` wholesale via `jest.mock`, which is exactly why this was never caught: a mock object can define whatever methods you give it, so it can't catch the real facade omitting one. This test requires the real facade against a temp SQLite file (same pattern as `dbAdapter.singleStore.test.js`) and checks:

1. the facade actually exposes both methods as functions,
2. a grant round-trips through the facade directly, and
3. `userScopeService.syncUserPeerGrants`/`getUserPeerGrantIds` actually persist through the real facade (not just through a mock).

Confirmed the new test fails on `dev` (`TypeError: db.setUserPeerGrants is not a function`) and passes with the fix. Full suite: 95 passed / 2 pre-existing skips, 620 tests, unrelated to this change.

## Manual verification

Also verified end-to-end against a live deployment (`docker-compose.quick.single.yml`, `:latest` image, SQLite backend): before the fix, `PATCH /api/users/:id` with a `peerIds` array returned `{"success":true}` but `user_peer_grants` stayed empty (confirmed by querying the table directly, not just trusting the API response). After applying the same two-line fix to the running container and restarting, the identical request produced a real row with the correct `user_id`/`peer_id`/`granted_at`. Applied it across a real 12-user, 19-device migration afterward with no further issues.

## Scope

Deliberately minimal — just the facade wiring + a regression test. Didn't touch anything else I noticed along the way (e.g. the `dockerfile`-pinned `3.5.47` image tag not currently being published to `ghcr.io/unitronix/betterdesk`, which meant I had to use `:latest` for my testing) since that's unrelated to this bug.
